### PR TITLE
Option error refactor

### DIFF
--- a/holoviews/core/options.py
+++ b/holoviews/core/options.py
@@ -376,7 +376,7 @@ class Options(param.Parameterized):
        Whether to merge with the existing keywords if the corresponding
        node already exists""")
 
-    skip_invalid = param.Boolean(default=True, doc="""
+    skip_invalid = param.Boolean(default=False, doc="""
        Whether all Options instances should skip invalid keywords or
        raise and exception. May only be specified at the class level.""")
 
@@ -388,6 +388,8 @@ class Options(param.Parameterized):
     def __init__(self, key=None, allowed_keywords=[], merge_keywords=True, max_cycles=None, **kwargs):
 
         invalid_kws = []
+        allowed_keywords = (allowed_keywords if isinstance(allowed_keywords, Keywords)
+                            else Keywords(allowed_keywords))
         for kwarg in sorted(kwargs.keys()):
             if allowed_keywords and kwarg not in allowed_keywords:
                 if self.skip_invalid:
@@ -403,8 +405,6 @@ class Options(param.Parameterized):
         self._options = []
         self._max_cycles = max_cycles
 
-        allowed_keywords = (allowed_keywords if isinstance(allowed_keywords, Keywords)
-                            else Keywords(allowed_keywords))
         super(Options, self).__init__(allowed_keywords=allowed_keywords,
                                       merge_keywords=merge_keywords, key=key)
 
@@ -1358,7 +1358,7 @@ class StoreOptions(object):
                                (option, objtype, current_backend, found))
             return
         error = OptionError(option, allowed_keywords, group, objtype, backend)
-        if Options.skip_invalid:
+        if not Options.skip_invalid:
             raise error
         elif Options.warn_on_skip:
             param.main.warning(error.format_options_error())

--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -73,6 +73,10 @@ class Config(param.ParameterizedFunction):
        recommended that users switch this on to update any uses of
        __call__ as it will be deprecated in future.""")
 
+    strict_opts_magic = param.Boolean(default=False, doc="""
+       Whether the opts magic should strictly validate options passed
+       to it or merely skip invalid options.""")
+
     image_rtol = param.Number(default=10e-6, doc="""
       The tolerance used to enforce regular sampling for regular,
       gridded data where regular sampling is expected. Expressed as the

--- a/holoviews/ipython/magics.py
+++ b/holoviews/ipython/magics.py
@@ -349,7 +349,9 @@ class OptsMagic(Magics):
             self.shell.run_cell(cell, store_history=STORE_HISTORY)
         else:
             try:
-                StoreOptions.validate_spec(spec)
+                with options_policy(skip_invalid=not config.strict_opts_magic,
+                                    warn_on_skip=True):
+                    StoreOptions.validate_spec(spec)
             except OptionError as e:
                 errmsg = erre.format_options_error()
                 sys.stderr.write(errmsg)

--- a/tests/core/testdimensioned.py
+++ b/tests/core/testdimensioned.py
@@ -1,5 +1,5 @@
 from holoviews.core.dimension import Dimensioned
-from holoviews.core.options import Store, Keywords, Options, OptionTree
+from holoviews.core.options import Store, Keywords, Options, OptionTree, OptionError
 from ..utils import LoggingComparisonTestCase
 
 class TestObj(Dimensioned):
@@ -49,26 +49,26 @@ class TestDimensioned_options(CustomBackendTestCase):
         err = ("Unexpected option 'style_opt3' for TestObj types "
                "across all extensions. Similar options for current "
                "extension \('backend_1'\) are: \['style_opt1', 'style_opt2'\]\.")
-        with self.assertRaisesRegexp(ValueError, err):
+        with self.assertRaisesRegexp(OptionError, err):
             TestObj([]).options(style_opt3='A')
 
     def test_apply_options_current_backend_style_invalid_no_match(self):
         err = ("Unexpected option 'zxy' for TestObj types across all extensions\. "
                "No similar options found\.")
-        with self.assertRaisesRegexp(ValueError, err):
+        with self.assertRaisesRegexp(OptionError, err):
             TestObj([]).options(zxy='A')
 
     def test_apply_options_explicit_backend_style_invalid_cross_backend(self):
         err = ("Unexpected option 'style_opt3' for TestObj types when "
                "using the 'backend_2' extension. Similar options are: "
                "\['style_opt1', 'style_opt2'\]\.")
-        with self.assertRaisesRegexp(ValueError, err):
+        with self.assertRaisesRegexp(OptionError, err):
             TestObj([]).options(style_opt3='A', backend='backend_2')
 
     def test_apply_options_explicit_backend_style_invalid_no_match(self):
         err = ("Unexpected option 'zxy' for TestObj types when using the "
                "'backend_2' extension. No similar options founds\.")
-        with self.assertRaisesRegexp(ValueError, err):
+        with self.assertRaisesRegexp(OptionError, err):
             TestObj([]).options(zxy='A', backend='backend_2')
 
     def test_apply_options_current_backend_style_invalid_cross_backend_match(self):
@@ -82,7 +82,7 @@ class TestDimensioned_options(CustomBackendTestCase):
         err = ("Unexpected option 'style_opt3' for TestObj types when "
                "using the 'backend_2' extension. Similar options are: "
                "\['style_opt1', 'style_opt2'\]\.")
-        with self.assertRaisesRegexp(ValueError, err):
+        with self.assertRaisesRegexp(OptionError, err):
             TestObj([]).options(style_opt3='A', backend='backend_2')
 
     def test_apply_options_current_backend_style_multiple(self):

--- a/tests/core/testoptions.py
+++ b/tests/core/testoptions.py
@@ -2,7 +2,7 @@ import os
 import pickle
 import numpy as np
 from holoviews import Store, StoreOptions, Histogram, Image
-from holoviews.core.options import OptionError, Cycle, Options, OptionTree, options_policy
+from holoviews.core.options import OptionError, Cycle, Options, OptionTree
 from holoviews.element.comparison import ComparisonTestCase
 from holoviews import plotting              # noqa Register backends
 from unittest import SkipTest
@@ -54,26 +54,6 @@ class TestOptions(ComparisonTestCase):
             Options('test', allowed_keywords=['kw2'], kw2='value', kw3='value')
         except OptionError as e:
             self.assertEqual(str(e), "Invalid option 'kw3', valid options are: ['kw2']")
-
-    def test_options_invalid_keywords_skip1(self):
-        with options_policy(skip_invalid=True, warn_on_skip=False):
-            opts = Options('test', allowed_keywords=['kw1'], kw='value')
-        self.assertEqual(opts.kwargs, {})
-
-    def test_options_invalid_keywords_skip2(self):
-        with options_policy(skip_invalid=True, warn_on_skip=False):
-            opts = Options('test', allowed_keywords=['kw1'], kw1='value', kw2='val')
-        self.assertEqual(opts.kwargs, {'kw1':'value'})
-
-
-    def test_options_record_invalid(self):
-        StoreOptions.start_recording_skipped()
-        with options_policy(skip_invalid=True, warn_on_skip=False):
-            Options('test', allowed_keywords=['kw1'], kw1='value', kw2='val')
-        errors = StoreOptions.stop_recording_skipped()
-        self.assertEqual(len(errors),1)
-        self.assertEqual(errors[0].invalid_keyword,'kw2')
-
 
     def test_options_get_options(self):
         opts = Options('test', allowed_keywords=['kw2', 'kw3'],

--- a/tests/core/testoptions.py
+++ b/tests/core/testoptions.py
@@ -593,8 +593,8 @@ class TestCrossBackendOptions(ComparisonTestCase):
 
     def clear_options(self):
         # Clear global options..
-        Store.options(val=OptionTree(groups=['plot', 'style']), backend='matplotlib')
-        Store.options(val=OptionTree(groups=['plot', 'style']), backend='bokeh')
+        Store.options(val=OptionTree([('Image', {})], groups=['plot', 'style']), backend='matplotlib')
+        Store.options(val=OptionTree([('Image', {})], groups=['plot', 'style']), backend='bokeh')
         # ... and custom options
         Store.custom_options({}, backend='matplotlib')
         Store.custom_options({}, backend='bokeh')


### PR DESCRIPTION
Picks up where https://github.com/ioam/holoviews/pull/2306 left off, completely refactoring option error handling. All methods of setting options will now either warn or error when given an invalid option. Could consider readding a skip option for the OptionsMagic, because that won't let you be explicit about the backend you're trying to set options on yet.

- [ ] Update existing unit tests
- [ ] Add new unit tests