### PR TITLE
Made shared_axes option supported generally and toggle axiswise when disabled

### DIFF
--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -352,8 +352,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
 
         plot_ranges = {}
         # Try finding shared ranges in other plots in the same Layout
-        norm_opts = self.lookup_options(el, 'norm').options
-        if plots and self.shared_axes and not norm_opts.get('axiswise', False):
+        if plots and self.shared_axes:
             plot_ranges = self._merge_ranges(plots, xspecs, yspecs)
 
         # Get the Element that determines the range and get_extents

--- a/holoviews/plotting/mpl/plot.py
+++ b/holoviews/plotting/mpl/plot.py
@@ -257,6 +257,10 @@ class CompositePlot(GenericCompositePlot, MPLPlot):
     subplots to form a Layout.
     """
 
+    shared_axes = param.Boolean(default=True, doc="""
+        Whether axes ranges should be shared across the layout, if
+        disabled switches axiswise normalization option on globally.""")
+
     def _link_dimensioned_streams(self):
         """
         Should perform any linking required to update titles when dimensioned

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -519,6 +519,7 @@ class DimensionedPlot(Plot):
         # been supplied from a composite plot
         return_fn = lambda x: x if isinstance(x, Element) else None
         for group, (axiswise, framewise) in norm_opts.items():
+            axiswise = not getattr(self, 'shared_axes', not axiswise)
             elements = []
             # Skip if ranges are cached or already computed by a
             # higher-level container object.

--- a/holoviews/plotting/plotly/plot.py
+++ b/holoviews/plotting/plotly/plot.py
@@ -61,6 +61,10 @@ class LayoutPlot(PlotlyPlot, GenericLayoutPlot):
     shared_axes = param.Boolean(default=True, doc="""
             Whether axes should be shared across plots""")
 
+    shared_axes = param.Boolean(default=True, doc="""
+        Whether axes ranges should be shared across the layout, if
+        disabled switches axiswise normalization option on globally.""")
+
     def __init__(self, layout, **params):
         super(LayoutPlot, self).__init__(layout, **params)
         self.layout, self.subplots, self.paths = self._init_layout(layout)
@@ -282,6 +286,10 @@ class GridPlot(PlotlyPlot, GenericCompositePlot):
     hspacing = param.Number(default=15, bounds=(0, None))
 
     vspacing = param.Number(default=15, bounds=(0, None))
+
+    shared_axes = param.Boolean(default=True, doc="""
+        Whether axes ranges should be shared across the layout, if
+        disabled switches axiswise normalization option on globally.""")
 
     def __init__(self, layout, ranges=None, layout_num=1, **params):
         if not isinstance(layout, GridSpace):

--- a/holoviews/tests/plotting/bokeh/testlayoutplot.py
+++ b/holoviews/tests/plotting/bokeh/testlayoutplot.py
@@ -272,16 +272,6 @@ class TestLayoutPlot(TestBokehPlot):
         p1, p2 = (sp.subplots['main'] for sp in plot.subplots.values())
         self.assertIsNot(p1.handles['y_range'], p2.handles['y_range'])
 
-    def test_dimensioned_streams_with_dynamic_map_overlay_clone(self):
-        time = Stream.define('Time', time=-3.0)()
-        def crosshair(time):
-            return VLine(time) * HLine(time)
-        crosshair = DynamicMap(crosshair, kdims='time', streams=[time])
-        path = Path([])
-        t = crosshair * path
-        html, _ = bokeh_renderer(t)
-        self.assertIn('Bokeh Application', html)
-
     def test_dimensioned_streams_with_dynamic_callback_returns_layout(self):
         stream = Stream.define('aname', aname='a')()
         def cb(aname):

--- a/holoviews/tests/plotting/bokeh/testlayoutplot.py
+++ b/holoviews/tests/plotting/bokeh/testlayoutplot.py
@@ -292,7 +292,7 @@ class TestLayoutPlot(TestBokehPlot):
         from holoviews.plotting.bokeh import CurvePlot
         layout = (Curve([1, 2, 3]) + Curve([10, 20, 30])).opts(shared_axes=False)
         plot = bokeh_renderer.get_plot(layout)
-        cp1, cp2 = plot.traverse(lambda x: x, [CurvePlot])
+        cp1, cp2 = plot.subplots[(0, 0)].subplots['main'], plot.subplots[(0, 1)].subplots['main']
         self.assertFalse(cp1.handles['y_range'] is cp2.handles['y_range'])
         self.assertEqual(cp1.handles['y_range'].start, 1)
         self.assertEqual(cp1.handles['y_range'].end, 3)

--- a/holoviews/tests/plotting/matplotlib/testlayoutplot.py
+++ b/holoviews/tests/plotting/matplotlib/testlayoutplot.py
@@ -47,3 +47,11 @@ class TestLayoutPlot(TestMPLPlot):
         self.assertIn('test: 1', plot.handles['title'].get_text())
         plot.cleanup()
         self.assertEqual(stream._subscribers, [])
+
+    def test_layout_shared_axes_disabled(self):
+        from holoviews.plotting.mpl import CurvePlot
+        layout = (Curve([1, 2, 3]) + Curve([10, 20, 30])).opts(shared_axes=False)
+        plot = mpl_renderer.get_plot(layout)
+        cp1, cp2 = plot.traverse(lambda x: x, [CurvePlot])
+        self.assertTrue(cp1.handles['axis'].get_ylim(), (1, 3))
+        self.assertTrue(cp2.handles['axis'].get_ylim(), (10, 30))


### PR DESCRIPTION
Disabling sharing of axes (i.e. setting axiswise=True) across a layout is currently quite awkward because you have to disable it on every single element in a layout. The shared_axes option that already existed for bokeh already provided some support for toggling this behavior, this PR generalizes it across backends.

- [x] Addresses https://github.com/ioam/holoviews/issues/3406