### PR TITLE
Compatibility with bokeh layout refactor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,6 +1,6 @@
 environment:
   global:
-    CHANS_DEV: "-c pyviz/label/dev -c conda-forge"
+    CHANS_DEV: "-c pyviz/label/dev -c conda-forge -c bokeh/label/dev"
   matrix:
     - PY: "2.7"
       CONDA: "C:\\Miniconda-x64"

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ env:
   global:
     - PYENV_VERSION=3.6
     - PKG_TEST_PYTHON="--test-python=py36 --test-python=py27"
-    - CHANS_DEV="-c pyviz/label/dev -c conda-forge"
+    - CHANS_DEV="-c pyviz/label/dev -c bokeh/label/dev -c conda-forge"
     - CHANS="-c pyviz"
     - MPLBACKEND="Agg"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -146,7 +146,7 @@ jobs:
     - &doc_build
       <<: *default
       stage: docs_dev
-      env: DESC="docs" CHANS_DEV="-c pyviz/label/dev" HV_DOC_HTML='true' HV_DOC_GALLERY='false' HV_REQUIREMENTS="doc"
+      env: DESC="docs" CHANS_DEV="-c pyviz/label/dev -c bokeh/label/dev" HV_DOC_HTML='true' HV_DOC_GALLERY='false' HV_REQUIREMENTS="doc"
       script:
         - bokeh sampledata
         - nbsite generate-rst --org pyviz --project-name holoviews --skip ^reference
@@ -158,7 +158,7 @@ jobs:
     - &gallery_build
       <<: *doc_build
       stage: gallery_dev
-      env: DESC="gallery" CHANS_DEV="-c pyviz/label/dev" HV_DOC_HTML='true' HV_REQUIREMENTS="doc" BUCKET="dev."
+      env: DESC="gallery" CHANS_DEV="-c pyviz/label/dev -c bokeh/label/dev" HV_DOC_HTML='true' HV_REQUIREMENTS="doc" BUCKET="dev."
       script:
         - bokeh sampledata
         - pip install awscli
@@ -175,7 +175,7 @@ jobs:
 
     - <<: *gallery_build
       stage: gallery_daily
-      env: DESC="gallery" CHANS_DEV="-c pyviz/label/dev" HV_DOC_HTML='true' HV_DOC_GALLERY='true' HV_REQUIREMENTS="doc" BUCKET="build."
+      env: DESC="gallery" CHANS_DEV="-c pyviz/label/dev -c bokeh/label/dev" HV_DOC_HTML='true' HV_DOC_GALLERY='true' HV_REQUIREMENTS="doc" BUCKET="build."
 
     - <<: *doc_build
       stage: docs

--- a/examples/user_guide/Plotting_with_Bokeh.ipynb
+++ b/examples/user_guide/Plotting_with_Bokeh.ipynb
@@ -153,14 +153,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Sizing Elements"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Sizing and aspect of Elements in bokeh are always computed in absolute pixels. To change the size or aspect of an Element set the ``width`` and ``height`` plot options."
+    "## Sizing Elements\n",
+    "\n",
+    "In the bokeh backend the sizing of plots and specifically layouts of plots is determined in an inside-out or compositional manner. Each subplot can be sized independently and it will fill the allocated space. The sizing is determined by the combination of width, height, aspect and responsive options. In this section we will discover the different approaches to setting plot dimensions and aspects. \n",
+    "\n",
+    "### Width and height\n",
+    "\n",
+    "The most straightforward approach to specifying the size of a plot is using a width and height specified in pixels. This is the default behavior and makes it easy to achieve precise alignment between plots but does not allow for keeping a constant aspect or responsive resizing. In particular, the specified size includes the axes and any legends or colorbars."
    ]
   },
   {
@@ -169,10 +168,75 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "points_a = hv.Points(data, label='A')\n",
-    "points_b = hv.Points(data, label='B')\n",
+    "points_a = hv.Points(data)\n",
+    "points_b = hv.Points(data)\n",
     "\n",
     "points_a.opts(width=300, height=300) + points_b.opts(width=600, height=300)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Frame width and height\n",
+    "\n",
+    "The frame width on the other hand provides precise control over the inner dimensions of a plot, it ensures the actual plot frame matches the specified dimensions exactly. This makes it possible to achieve a precise aspect ratio between the axis scales, without worrying about the size of axes, colorbars, titles and legends, e.g. below we can see two plots defined using explicit ``frame_width`` and ``frame_height`` share the same dimensions despite the fact that one has a colorbar."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "xs = ys  = np.arange(10)\n",
+    "yy, xx = np.meshgrid(xs, ys)\n",
+    "zz = xx*yy\n",
+    "\n",
+    "img = hv.Image(np.random.rand(100, 100))\n",
+    "\n",
+    "points_a.opts(frame_width=200, frame_height=200) +\\\n",
+    "img.opts(frame_width=200, frame_height=200, colorbar=True, axiswise=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Aspect\n",
+    "\n",
+    "The ``aspect`` and ``data_aspect`` options provide control over the scaling of the plot dimensions and the axis limits.\n",
+    "\n",
+    "#### ``aspect``:\n",
+    "\n",
+    "The ``aspect`` specifies the ratio between the width and height dimensions of the plot. If specified this options takes absolute precedence over the dimensions of the plot but has no effect on the plot's axis limits. It supports the following options:\n",
+    "\n",
+    "* **``float``** : A numeric value will scale the ratio of plot width to plot height\n",
+    "* **``\"equal\"``** : Sets aspect of the axis scaling to be equal, equivalent to **``data_aspect=1``**\n",
+    "* **``\"square\"``** : Ensures the plot dimensions are square.\n",
+    "\n",
+    "#### ``data_aspect``:\n",
+    "\n",
+    "The ``data_aspect`` specifies the scaling between the x- and y-axis ranges. If specified this option will scale both the plot ranges and dimensions unless explicit ``aspect``, ``width`` or ``height`` value overrides the plot dimensions:\n",
+    "\n",
+    "* **``float``** : Sets aspect of the axis scaling to be equal"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "xs = np.linspace(0, 10)\n",
+    "ys = np.linspace(0, 5)\n",
+    "\n",
+    "img = hv.Image((xs, ys, xs[:, np.newaxis]*np.sin(ys*4)))\n",
+    "\n",
+    "(img.options(aspect='equal').relabel('aspect=\\'equal\\'') +\n",
+    " img.options(aspect='square', colorbar=True, width=300).relabel('aspect=\\'square\\'') +\n",
+    " img.options(aspect=2).relabel('aspect=2') + \n",
+    " img.options(data_aspect=2, width=150).relabel('data_aspect=2')).cols(2)"
    ]
   },
   {

--- a/examples/user_guide/Plotting_with_Bokeh.ipynb
+++ b/examples/user_guide/Plotting_with_Bokeh.ipynb
@@ -219,7 +219,7 @@
     "\n",
     "The ``data_aspect`` specifies the scaling between the x- and y-axis ranges. If specified this option will scale both the plot ranges and dimensions unless explicit ``aspect``, ``width`` or ``height`` value overrides the plot dimensions:\n",
     "\n",
-    "* **``float``** : Sets aspect of the axis scaling to be equal"
+    "* **``float``** : Sets ratio between the units on the x-scale and the y-scale"
    ]
   },
   {
@@ -236,7 +236,50 @@
     "(img.options(aspect='equal').relabel('aspect=\\'equal\\'') +\n",
     " img.options(aspect='square', colorbar=True, width=300).relabel('aspect=\\'square\\'') +\n",
     " img.options(aspect=2).relabel('aspect=2') + \n",
-    " img.options(data_aspect=2, width=150).relabel('data_aspect=2')).cols(2)"
+    " img.options(data_aspect=2, width=300).relabel('data_aspect=2')).cols(2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Responsive\n",
+    "\n",
+    "Since bokeh plots are rendered within a browser window which can be resized dynamically it supports responsive sizing modes allowing the plot to rescale when the window it is placed in is changed. If enabled, the behavior of ``responsive`` modes depends on whether an aspect or width/height option is set. Specifically responsive mode will only work if at least one dimension of the plot is left undefined, e.g. when width and height or width and aspect are set the plot is set to a fixed size, ignoring any ``responsive`` option. This leaves four different ``responsive`` modes:\n",
+    "\n",
+    "* **``scale_both``**: If neither a width or a height are defined but a fixed aspect is defined both axes will be scaled up to the maximum size of the container. Scaling ensures that the aspect ratio of the plot is maintained.\n",
+    "* **``stretch_both``**: If neither a width, height or aspect are defined the plot will stretch to fill all available space.\n",
+    "* **``stretch_width``**: If a height but neither a width or aspect are defined the plot will stretch to fill all available horizontal space.\n",
+    "* **``stretch_height``**: If a width but neither a height or aspect are defined the plot will stretch to fill all available vertical space.\n",
+    "\n",
+    "**Note**: In the notebook stretching and scaling the height does not increase the size of a cell.\n",
+    "\n",
+    "As a simple example let us declare a plot that has a fixed height but stretches to fit all available horizontal space:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hv.Points(data).opts(height=200, responsive=True, title='stretch width')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Similarly if we declare a fixed ``aspect`` or ``data_aspect`` responsive modes will try to fill all available space but avoid distorting the specified aspect:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "img.opts(data_aspect=10, responsive=True, title='scale both')"
    ]
   },
   {

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -853,17 +853,23 @@ class ElementPlot(BokehPlot, GenericElementPlot):
                 # After initial draw or if aspect is explicit
                 # adjust range to match the plot dimension aspect
                 ratio = self.data_aspect or 1
-                if self.aspect:
+                if self.aspect == 'square':
+                    frame_aspect = 1
+                elif self.aspect and self.aspect != 'equal':
                     frame_aspect = self.aspect
                 else:
                     frame_aspect = plot.frame_width/plot.frame_height
+
+                desired_xspan = yspan*1./(ratio/frame_aspect)
                 desired_yspan = (xspan*(ratio/frame_aspect))
-                if desired_yspan >= yspan:
+                if (np.allclose(desired_xspan, xspan, rtol=0.01) and
+                    np.allclose(desired_yspan, yspan, rtol=0.01)):
+                    pass
+                elif desired_yspan >= yspan:
                     ypad = (desired_yspan-yspan)/2.
                     b, t = b-ypad, t+ypad
                     yupdate = True
                 else:
-                    desired_xspan = yspan*1./(ratio/frame_aspect)
                     xpad = (desired_xspan-xspan)/2.
                     l, r = l-xpad, r+xpad
                     xupdate = True

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -1908,8 +1908,8 @@ class OverlayPlot(GenericOverlayPlot, LegendPlot):
                           'xlabel', 'ylabel', 'xlim', 'ylim', 'zlim',
                           'xformatter', 'yformatter', 'active_tools',
                           'min_height', 'max_height', 'min_width', 'min_height',
-                          'width_policy', 'height_policy', 'margin', 'aspect',
-                          'data_aspect']
+                          'margin', 'aspect', 'data_aspect', 'frame_width',
+                          'frame_height', 'responsive']
 
     def __init__(self, overlay, **params):
         super(OverlayPlot, self).__init__(overlay, **params)

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -60,7 +60,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
     border = param.Number(default=10, doc="""
         Minimum border around plot.""")
 
-    aspect = param.Parameter(default='square', doc="""
+    aspect = param.Parameter(default=None, doc="""
         The aspect ratio mode of the plot. By default, a plot may
         select its own appropriate aspect ratio but sometimes it may
         be necessary to force a square aspect ratio (e.g. to display
@@ -530,6 +530,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
             width = None
         else:
             width = int(self.width*size_multiplier)
+
         plot_props = {
             'css_classes':   self.css_classes,
             'margin':        self.margin,

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -551,6 +551,11 @@ class ElementPlot(BokehPlot, GenericElementPlot):
             width, height = None, None
             match_aspect = True
             aspect_scale = 1 if self.aspect == 'equal' else self.data_aspect
+            if self.dynamic:
+                # Sync the plot size on dynamic plots to support accurate
+                # scaling of dimension ranges
+                stream = PlotSize(subscribers=[self._update_size])
+                self.callbacks.append(PlotSizeCallback(self, [stream], None))
         elif util.isnumeric(aspect):
             if self.responsive:
                 aspect_ratio = aspect
@@ -585,8 +590,6 @@ class ElementPlot(BokehPlot, GenericElementPlot):
                 'plot_height':   height,
                 'plot_width':    width,
             })
-
-        print(plot_props)
 
         if self.bgcolor:
             plot_props['background_fill_color'] = self.bgcolor
@@ -839,7 +842,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
             yspan = t-b if util.is_number(b) and util.is_number(t) else None
             if self.drawn or self.aspect not in ['equal' or None]:
                 # After initial draw or if aspect is explicit
-                # adjust range to match initial aspect
+                # adjust range to match the plot dimension aspect
                 ratio = self.data_aspect or 1
                 if self.aspect:
                     frame_aspect = self.aspect

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -35,14 +35,11 @@ from .callbacks import PlotSizeCallback
 from .plot import BokehPlot
 from .styles import (
     legend_dimensions, line_properties, mpl_to_bokeh, property_prefixes,
-    rgba_tuple, text_properties, validate
-)
+    rgba_tuple, text_properties, validate)
 from .util import (
-    TOOL_TYPES, bokeh_version, date_to_integer, decode_bytes,
-    get_tab_title, glyph_order, py2js_tickformatter,
-    recursive_model_update, theme_attr_json, cds_column_replace,
-    hold_policy, match_dim_specs
-)
+    TOOL_TYPES, date_to_integer, decode_bytes, get_tab_title,
+    glyph_order, py2js_tickformatter, recursive_model_update,
+    theme_attr_json, cds_column_replace, hold_policy, match_dim_specs)
 
 
 
@@ -559,9 +556,11 @@ class ElementPlot(BokehPlot, GenericElementPlot):
             elif fixed_width:
                 frame_width = actual_width
                 frame_height = int(actual_width/aspect)
+                width, height = None, None
             else:
                 frame_width = int(actual_height*aspect)
                 frame_height = actual_height
+                width, height = None, None
         elif aspect is not None:
             self.param.warning('aspect value of type %s not recognized, '
                                'provide a numeric value, \'equal\' or '
@@ -850,7 +849,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
             plot = self.handles['plot']
             xspan = r-l if util.is_number(l) and util.is_number(r) else None
             yspan = t-b if util.is_number(b) and util.is_number(t) else None
-            if self.drawn or self.aspect not in ['equal' or None]:
+            if self.drawn or self.aspect not in ['equal', None]:
                 # After initial draw or if aspect is explicit
                 # adjust range to match the plot dimension aspect
                 ratio = self.data_aspect or 1
@@ -926,15 +925,12 @@ class ElementPlot(BokehPlot, GenericElementPlot):
                     "than or equal to zero, please supply explicit "
                     "lower-bound to override default of %.3f." % low)
             updates = {}
-            reset_supported = bokeh_version > '0.12.16'
             if util.isfinite(low):
                 updates['start'] = (axis_range.start, low)
-                if reset_supported:
-                    updates['reset_start'] = updates['start']
+                updates['reset_start'] = updates['start']
             if util.isfinite(high):
                 updates['end'] = (axis_range.end, high)
-                if reset_supported:
-                    updates['reset_end'] = updates['end']
+                updates['reset_end'] = updates['end']
             for k, (old, new) in updates.items():
                 if isinstance(new, util.cftime_types):
                     new = date_to_integer(new)

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -31,10 +31,11 @@ from ...core import DynamicMap, CompositeOverlay, Element, Dimension
 from ...core.options import abbreviated_exception, SkipRendering
 from ...core import util
 from ...element import Graph, VectorField, Path, Contours, Tiles
-from ...streams import Buffer
+from ...streams import Buffer, PlotSize
 from ...util.transform import dim
 from ..plot import GenericElementPlot, GenericOverlayPlot
 from ..util import dynamic_update, process_cmap, color_intervals, dim_range_key
+from .callbacks import PlotSizeCallback
 from .plot import BokehPlot
 from .styles import (
     legend_dimensions, line_properties, mpl_to_bokeh, property_prefixes,
@@ -601,6 +602,9 @@ class ElementPlot(BokehPlot, GenericElementPlot):
             plot_props['lod_'+lod_prop] = v
         return plot_props
 
+    def _update_size(self, width, height, scale):
+        self.state.frame_width = width
+        self.state.frame_height = height
 
     def _set_active_tools(self, plot):
         "Activates the list of active tools"

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -1620,7 +1620,6 @@ class LegendPlot(ElementPlot):
             pos = self.legend_position
             if pos in self.legend_specs:
                 plot.legend[:] = []
-                legend.plot = None
                 legend.location = self.legend_offset
                 if pos in ['top', 'bottom']:
                     plot.legend.orientation = 'horizontal'
@@ -1760,7 +1759,6 @@ class OverlayPlot(GenericOverlayPlot, LegendPlot):
             legend.items[:] = []
         elif pos in ['above', 'below', 'right', 'left']:
             plot.legend.pop(plot.legend.index(legend))
-            legend.plot = None
             legend.location = self.legend_offset
             plot.add_layout(legend, pos)
 

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -483,7 +483,6 @@ class ElementPlot(BokehPlot, GenericElementPlot):
             self.callbacks.append(PlotSizeCallback(self, [stream], None))
 
         plot_props = {
-            'css_classes':   self.css_classes,
             'margin':        self.margin,
             'max_width':     self.max_width,
             'max_height':    self.max_height,

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -472,8 +472,6 @@ class ElementPlot(BokehPlot, GenericElementPlot):
             options['width'], options['height'], self.aspect, self.data_aspect,
             self.responsive, size_multiplier, logger=logger)
 
-        print(aspect_props, dimension_props)
-
         if not init:
             if aspect_props['aspect_ratio'] is None:
                 aspect_props['aspect_ratio'] = self.state.aspect_ratio

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -564,6 +564,10 @@ class ElementPlot(BokehPlot, GenericElementPlot):
             pass
         elif self.data_aspect or self.aspect == 'equal':
             match_aspect = True
+            if fixed_width or not fixed_height:
+                height = None
+            if fixed_height or not fixed_width:
+                width = None
             aspect_scale = 1 if self.aspect == 'equal' else self.data_aspect
             if self.dynamic:
                 # Sync the plot size on dynamic plots to support accurate
@@ -864,6 +868,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
         xaxis, yaxis = self.handles['xaxis'], self.handles['yaxis']
         categorical = isinstance(xaxis, CategoricalAxis) or isinstance(yaxis, CategoricalAxis)
         datetime = isinstance(xaxis, DatetimeAxis) or isinstance(yaxis, CategoricalAxis)
+
         if data_aspect and fixed_width and fixed_height:
             pass
         elif data_aspect and (categorical or datetime):
@@ -911,9 +916,11 @@ class ElementPlot(BokehPlot, GenericElementPlot):
                 if fixed_height:
                     plot.frame_height = height
                     plot.frame_width = int(height*aspect)
+                    plot.plot_width, plot.plot_height = None, None
                 elif fixed_width:
                     plot.frame_width = width
                     plot.frame_height = int(width/aspect)
+                    plot.plot_width, plot.plot_height = None, None
                 else:
                     plot.aspect_ratio = aspect
 

--- a/holoviews/plotting/bokeh/plot.py
+++ b/holoviews/plotting/bokeh/plot.py
@@ -48,8 +48,12 @@ class BokehPlot(DimensionedPlot):
 
     sizing_mode = param.ObjectSelector(default='fixed',
         objects=['fixed', 'stretch_both', 'scale_width', 'scale_height',
-                 'scale_both'], doc="""
+                 'scale_both', 'auto'], doc="""
         How the item being displayed should size itself.
+
+        "auto" mode will use 'fixed' sizing when no aspect is defined
+        otherwise it will use 'scale_width' or 'scale_height' depending
+        on whether the aspect exceeds.
 
         "stretch_both" plots will resize to occupy all available
         space, even if this changes the aspect ratio of the element.
@@ -677,7 +681,6 @@ class GridPlot(CompositePlot, GenericCompositePlot):
     def _make_axes(self, plot):
         width, height = self.renderer.get_size(plot)
         x_axis, y_axis = None, None
-        kwargs = dict(sizing_mode=self.sizing_mode)
         keys = self.layout.keys(full_grid=True)
         if self.xaxis:
             flip = self.shared_xaxis
@@ -704,15 +707,15 @@ class GridPlot(CompositePlot, GenericCompositePlot):
                 r1, r2 = r2, r1
             if self.shared_yaxis:
                 r1, r2 = r1[::-1], r2[::-1]
-            plot = gridplot([r1, r2], **kwargs)
+            plot = gridplot([r1, r2])
         elif y_axis:
             models = [y_axis, plot]
             if self.shared_yaxis: models = models[::-1]
-            plot = Row(*models, **kwargs)
+            plot = Row(*models)
         elif x_axis:
             models = [plot, x_axis]
             if self.shared_xaxis: models = models[::-1]
-            plot = Column(*models, **kwargs)
+            plot = Column(*models)
         return plot
 
 
@@ -998,7 +1001,7 @@ class LayoutPlot(CompositePlot, GenericLayoutPlot):
         title = self._get_title_div(self.keys[-1])
         if title:
             self.handles['title'] = title
-            layout_plot = Column(title, layout_plot, **kwargs)
+            layout_plot = Column(title, layout_plot)
 
         self.handles['plot'] = layout_plot
         self.handles['plots'] = plots

--- a/holoviews/plotting/bokeh/plot.py
+++ b/holoviews/plotting/bokeh/plot.py
@@ -704,8 +704,7 @@ class GridPlot(CompositePlot, GenericCompositePlot):
                 r1, r2 = r2, r1
             if self.shared_yaxis:
                 r1, r2 = r1[::-1], r2[::-1]
-            models = layout_padding([r1, r2], self.renderer)
-            plot = gridplot(models, **kwargs)
+            plot = gridplot([r1, r2], **kwargs)
         elif y_axis:
             models = [y_axis, plot]
             if self.shared_yaxis: models = models[::-1]

--- a/holoviews/plotting/bokeh/plot.py
+++ b/holoviews/plotting/bokeh/plot.py
@@ -28,10 +28,8 @@ from ..plot import (
 from ..util import attach_streams, displayable, collate
 from .callbacks import LinkCallback
 from .util import (
-    TOOL_TYPES, layout_padding, pad_plots, filter_toolboxes,
-    make_axis, update_shared_sources, empty_plot, decode_bytes,
-    theme_attr_json, cds_column_replace
-)
+    TOOL_TYPES, filter_toolboxes, make_axis, update_shared_sources,
+    empty_plot, decode_bytes, theme_attr_json, cds_column_replace)
 
 
 class BokehPlot(DimensionedPlot):

--- a/holoviews/plotting/bokeh/plot.py
+++ b/holoviews/plotting/bokeh/plot.py
@@ -985,18 +985,15 @@ class LayoutPlot(CompositePlot, GenericLayoutPlot):
                 passed_plots.append(subplots[0])
 
         # Wrap in appropriate layout model
-        kwargs = dict(sizing_mode=self.sizing_mode)
         if self.tabs:
             plots = filter_toolboxes([p for t, p in tab_plots])
             panels = [Panel(child=child, title=t) for t, child in tab_plots]
             layout_plot = Tabs(tabs=panels)
         else:
-            plot_grid = layout_padding(plot_grid, self.renderer)
             plot_grid = filter_toolboxes(plot_grid)
-            plot_grid = pad_plots(plot_grid)
             layout_plot = gridplot(children=plot_grid,
                                    toolbar_location=self.toolbar,
-                                   merge_tools=self.merge_tools, **kwargs)
+                                   merge_tools=self.merge_tools)
 
         title = self._get_title_div(self.keys[-1])
         if title:

--- a/holoviews/plotting/bokeh/plot.py
+++ b/holoviews/plotting/bokeh/plot.py
@@ -38,9 +38,6 @@ class BokehPlot(DimensionedPlot):
     plotting interface for Bokeh based plots.
     """
 
-    css_classes = param.List(default=[], doc="""
-        CSS classes to apply to the layout.""")
-
     shared_datasource = param.Boolean(default=True, doc="""
         Whether Elements drawing the data from the same object should
         share their Bokeh data source allowing for linked brushing
@@ -450,12 +447,6 @@ class CompositePlot(BokehPlot):
         'scale_width', 'scale_height', 'scale_both', None], doc="""
 
         How the component should size itself.
-
-        This is a high-level setting for maintaining width and height
-        of the component. To gain more fine grained control over
-        sizing, use ``width_policy``, ``height_policy`` and
-        ``aspect_ratio`` instead (those take precedence over
-        ``sizing_mode``).
 
         * "fixed" :
           Component is not responsive. It will retain its original

--- a/holoviews/plotting/bokeh/plot.py
+++ b/holoviews/plotting/bokeh/plot.py
@@ -572,8 +572,10 @@ class GridPlot(CompositePlot, GenericCompositePlot):
     yrotation = param.Integer(default=0, bounds=(0, 360), doc="""
         Rotation angle of the yticks.""")
 
-    plot_size = param.Integer(default=120, doc="""
-        Defines the width and height of each plot in the grid""")
+    plot_size = param.ClassSelector(default=120, class_=(int, tuple), doc="""
+        Defines the width and height of each plot in the grid, either
+        as a tuple specifying width and height or an integer for a
+        square plot.""")
 
     def __init__(self, layout, ranges=None, layout_num=1, keys=None, **params):
         if not isinstance(layout, GridSpace):
@@ -596,6 +598,11 @@ class GridPlot(CompositePlot, GenericCompositePlot):
 
 
     def _create_subplots(self, layout, ranges):
+        if isinstance(self.plot_size, tuple):
+            width, height = self.plot_size
+        else:
+            width, height = self.plot_size, self.plot_size
+
         subplots = OrderedDict()
         frame_ranges = self.compute_ranges(layout, None, ranges)
         keys = self.keys[:1] if self.dynamic else self.keys
@@ -622,8 +629,10 @@ class GridPlot(CompositePlot, GenericCompositePlot):
 
             # Create axes
             kwargs = {}
-            kwargs['frame_width'] = self.plot_size
-            kwargs['frame_height'] = self.plot_size
+            if width is not None:
+                kwargs['frame_width'] = width
+            if height is not None:
+                kwargs['frame_height'] = height
             if c == 0 and r != 0:
                 kwargs['xaxis'] = None
             if c != 0 and r == 0:

--- a/holoviews/plotting/bokeh/renderer.py
+++ b/holoviews/plotting/bokeh/renderer.py
@@ -336,7 +336,11 @@ class BokehRenderer(Renderer):
         options = plot.lookup_options(obj, 'plot').options
         width = options.get('width', plot.width)
         height = options.get('height', plot.height)
-        return dict(options, **{'width':int(width), 'height': int(height)})
+        if width is not None:
+            width = int(width)
+        if height is not None:
+            height = int(height)
+        return dict(options, **{'width': width, 'height': height})
 
 
     @bothmethod

--- a/holoviews/plotting/bokeh/tabular.py
+++ b/holoviews/plotting/bokeh/tabular.py
@@ -14,12 +14,9 @@ from ...streams import Buffer
 from ...core.util import dimension_sanitizer, datetime_types
 from ..plot import GenericElementPlot
 from .plot import BokehPlot
-from .util import bokeh_version
 
 
 class TablePlot(BokehPlot, GenericElementPlot):
-
-    height = param.Number(default=None)
 
     finalize_hooks = param.HookList(default=[], doc="""
         Deprecated; use hooks options instead.""")
@@ -29,13 +26,13 @@ class TablePlot(BokehPlot, GenericElementPlot):
         hook is passed the plot object and the displayed element, and
         other plotting handles can be accessed via plot.handles.""")
 
+    height = param.Number(default=300)
+
     width = param.Number(default=400)
 
-    style_opts = (
-        ['row_headers', 'selectable', 'editable',
-         'sortable', 'fit_columns', 'scroll_to_selection'] +
-        (['index_position'] if bokeh_version >= '0.12.15' else [])
-        )
+    style_opts = ['row_headers', 'selectable', 'editable',
+                  'sortable', 'fit_columns', 'scroll_to_selection',
+                  'index_position']
 
     _stream_data = True
 

--- a/holoviews/plotting/bokeh/util.py
+++ b/holoviews/plotting/bokeh/util.py
@@ -17,7 +17,7 @@ from bokeh.core.json_encoder import serialize_json # noqa (API import)
 from bokeh.core.properties import value
 from bokeh.layouts import WidgetBox, Row, Column
 from bokeh.models import tools
-from bokeh.models import Model, ToolbarBox, FactorRange, Range1d, Plot, Spacer, CustomJS
+from bokeh.models import Model, ToolbarBox, FactorRange, Range1d, Plot, Spacer, CustomJS, GridBox
 from bokeh.models.widgets import DataTable, Tabs, Div
 from bokeh.plotting import Figure
 from bokeh.themes.theme import Theme
@@ -136,7 +136,9 @@ def compute_plot_size(plot):
     Computes the size of bokeh models that make up a layout such as
     figures, rows, columns, widgetboxes and Plot.
     """
-    if isinstance(plot, (Div, ToolbarBox)):
+    if isinstance(plot, GridBox):
+        return 0, 0 # Temporary hack, should be handled properly
+    elif isinstance(plot, (Div, ToolbarBox)):
         # Cannot compute size for Div or ToolbarBox
         return 0, 0
     elif isinstance(plot, (Row, Column, WidgetBox, Tabs)):
@@ -160,15 +162,7 @@ def empty_plot(width, height):
     """
     Creates an empty and invisible plot of the specified size.
     """
-    x_range = Range1d(start=0, end=1)
-    y_range = Range1d(start=0, end=1)
-    p = Figure(plot_width=width, plot_height=height,
-               x_range=x_range, y_range=y_range)
-    p.xaxis.visible = False
-    p.yaxis.visible = False
-    p.outline_line_alpha = 0
-    p.grid.grid_line_alpha = 0
-    return p
+    return Spacer(width=width, height=height)
 
 
 def font_size_to_pixels(size):

--- a/holoviews/plotting/bokeh/util.py
+++ b/holoviews/plotting/bokeh/util.py
@@ -138,7 +138,7 @@ def compute_plot_size(plot):
     figures, rows, columns, widgetboxes and Plot.
     """
     if isinstance(plot, GridBox):
-        ndmapping = NdMapping({(x, y): fig for fig, x, y in plot.children}, kdims=['x', 'y'])
+        ndmapping = NdMapping({(x, y): fig for fig, y, x in plot.children}, kdims=['x', 'y'])
         cols = ndmapping.groupby('x')
         rows = ndmapping.groupby('y')
         width = sum([max([compute_plot_size(f)[0] for f in col]) for col in cols])

--- a/holoviews/plotting/bokeh/util.py
+++ b/holoviews/plotting/bokeh/util.py
@@ -158,7 +158,15 @@ def compute_plot_size(plot):
         widths, heights = zip(*[compute_plot_size(child) for child in plot.children])
         return w_agg(widths), h_agg(heights)
     elif isinstance(plot, (Figure, Chart)):
-        return plot.plot_width, plot.plot_height
+        if plot.plot_width:
+            width = plot.plot_width
+        else:
+            width = plot.frame_width + plot.min_border_right + plot.min_border_left
+        if plot.plot_height:
+            height = plot.plot_height
+        else:
+            height = plot.frame_height + plot.min_border_bottom + plot.min_border_top
+            return width, height
     elif isinstance(plot, (Plot, DataTable, Spacer)):
         return plot.width, plot.height
     else:

--- a/holoviews/plotting/bokeh/util.py
+++ b/holoviews/plotting/bokeh/util.py
@@ -180,6 +180,23 @@ def compute_layout_properties(
     """
     Utility to compute the aspect, plot width/height and sizing_mode
     behavior.
+
+    Args:
+      width (int): Plot width
+      height (int): Plot height
+      frame_width (int): Plot frame width
+      frame_height (int): Plot frame height
+      explicit_width (list): List of user supplied widths
+      explicit_height (list): List of user supplied heights
+      aspect (float): Plot aspect
+      data_aspect (float): Scaling between x-axis and y-axis ranges
+      responsive (boolean): Whether the plot should resize responsively
+      size_multiplier (float): Multiplier for supplied plot dimensions
+      logger (param.Parameters): Parameters object to issue warnings on
+
+    Returns:
+      Returns two dictionaries one for the aspect and sizing modes,
+      and another for the plot dimensions.
     """
     fixed_width = (explicit_width or frame_width)
     fixed_height = (explicit_height or frame_height)

--- a/holoviews/plotting/bokeh/util.py
+++ b/holoviews/plotting/bokeh/util.py
@@ -166,7 +166,7 @@ def compute_plot_size(plot):
             height = plot.plot_height
         else:
             height = plot.frame_height + plot.min_border_bottom + plot.min_border_top
-            return width, height
+        return width, height
     elif isinstance(plot, (Plot, DataTable, Spacer)):
         return plot.width, plot.height
     else:

--- a/holoviews/plotting/mpl/element.py
+++ b/holoviews/plotting/mpl/element.py
@@ -34,7 +34,14 @@ class ElementPlot(GenericElementPlot, MPLPlot):
         be necessary to force a square aspect ratio (e.g. to display
         the plot as an element of a grid). The modes 'auto' and
         'equal' correspond to the axis modes of the same name in
-        matplotlib, a numeric value may also be passed.""")
+        matplotlib, a numeric value specifying the ratio between plot
+        width and height may also be passed. To control the aspect
+        ratio between the axis scales use the data_aspect option
+        instead.""")
+
+    data_aspect = param.Number(default=None, doc="""
+        Defines the aspect of the axis scaling, i.e. the ratio of
+        y-unit to x-unit.""")
 
     invert_zaxis = param.Boolean(default=False, doc="""
         Whether to invert the plot z-axis.""")
@@ -288,19 +295,19 @@ class ElementPlot(GenericElementPlot, MPLPlot):
         """
         Set the aspect on the axes based on the aspect setting.
         """
-        if isinstance(aspect, util.basestring) and aspect != 'square':
-            axes.set_aspect(aspect)
-            return
-
-        (x0, x1), (y0, y1) = axes.get_xlim(), axes.get_ylim()
-        xsize = np.log(x1) - np.log(x0) if self.logx else x1-x0
-        ysize = np.log(y1) - np.log(y0) if self.logy else y1-y0
-        xsize = max(abs(xsize), 1e-30)
-        ysize = max(abs(ysize), 1e-30)
-        data_ratio = 1./(ysize/xsize)
-        if aspect != 'square':
-            data_ratio = data_ratio/aspect
-        axes.set_aspect(float(data_ratio))
+        if ((isinstance(aspect, util.basestring) and aspect != 'square') or
+            self.data_aspect):
+            data_ratio = self.data_aspect or aspect
+        else:
+            (x0, x1), (y0, y1) = axes.get_xlim(), axes.get_ylim()
+            xsize = np.log(x1) - np.log(x0) if self.logx else x1-x0
+            ysize = np.log(y1) - np.log(y0) if self.logy else y1-y0
+            xsize = max(abs(xsize), 1e-30)
+            ysize = max(abs(ysize), 1e-30)
+            data_ratio = 1./(ysize/xsize)
+            if aspect != 'square':
+                data_ratio = data_ratio/aspect
+        axes.set_aspect(data_ratio)
 
 
     def _set_axis_limits(self, axis, view, subplots, ranges):
@@ -959,7 +966,7 @@ class OverlayPlot(LegendPlot, GenericOverlayPlot):
                           'zrotation', 'invert_xaxis', 'invert_yaxis',
                           'invert_zaxis', 'title', 'title_format', 'padding',
                           'xlabel', 'ylabel', 'zlabel', 'xlim', 'ylim', 'zlim',
-                          'xformatter', 'yformatter']
+                          'xformatter', 'yformatter', 'data_aspect']
 
     def __init__(self, overlay, ranges=None, **params):
         if 'projection' not in params:

--- a/holoviews/plotting/mpl/raster.py
+++ b/holoviews/plotting/mpl/raster.py
@@ -186,6 +186,7 @@ class RasterGridPlot(GridPlot, OverlayPlot):
     apply_ticks = param.Parameter(precedence=-1)
     batched = param.Parameter(precedence=-1)
     bgcolor = param.Parameter(precedence=-1)
+    data_aspect = param.Parameter(precedence=-1)
     default_span = param.Parameter(precedence=-1)
     invert_axes = param.Parameter(precedence=-1)
     invert_xaxis = param.Parameter(precedence=-1)

--- a/holoviews/tests/plotting/bokeh/testelementplot.py
+++ b/holoviews/tests/plotting/bokeh/testelementplot.py
@@ -377,6 +377,8 @@ class TestElementPlot(LoggingComparisonTestCase, TestBokehPlot):
     def test_element_aspect(self):
         curve = Curve([1, 2, 3]).opts(aspect=2)
         plot = bokeh_renderer.get_plot(curve)
+        self.assertEqual(plot.state.plot_height, None)
+        self.assertEqual(plot.state.plot_width, None)
         self.assertEqual(plot.state.frame_height, 300)
         self.assertEqual(plot.state.frame_width, 600)
         self.assertEqual(plot.state.aspect_ratio, None)
@@ -384,6 +386,8 @@ class TestElementPlot(LoggingComparisonTestCase, TestBokehPlot):
     def test_element_aspect_width(self):
         curve = Curve([1, 2, 3]).opts(aspect=2, width=400)
         plot = bokeh_renderer.get_plot(curve)
+        self.assertEqual(plot.state.plot_height, None)
+        self.assertEqual(plot.state.plot_width, None)
         self.assertEqual(plot.state.frame_height, 200)
         self.assertEqual(plot.state.frame_width, 400)
         self.assertEqual(plot.state.aspect_ratio, None)
@@ -391,6 +395,8 @@ class TestElementPlot(LoggingComparisonTestCase, TestBokehPlot):
     def test_element_aspect_height(self):
         curve = Curve([1, 2, 3]).opts(aspect=2, height=400)
         plot = bokeh_renderer.get_plot(curve)
+        self.assertEqual(plot.state.plot_height, None)
+        self.assertEqual(plot.state.plot_width, None)
         self.assertEqual(plot.state.frame_height, 400)
         self.assertEqual(plot.state.frame_width, 800)
         self.assertEqual(plot.state.aspect_ratio, None)
@@ -398,14 +404,18 @@ class TestElementPlot(LoggingComparisonTestCase, TestBokehPlot):
     def test_element_aspect_width_height(self):
         curve = Curve([1, 2, 3]).opts(aspect=2, height=400, width=400)
         plot = bokeh_renderer.get_plot(curve)
-        self.log_handler.assertContains('WARNING', "aspect value was ignored")
         self.assertEqual(plot.state.plot_height, 400)
         self.assertEqual(plot.state.plot_width, 400)
+        self.assertEqual(plot.state.frame_height, None)
+        self.assertEqual(plot.state.frame_width, None)
         self.assertEqual(plot.state.aspect_ratio, None)
+        self.log_handler.assertContains('WARNING', "aspect value was ignored")
 
     def test_element_aspect_frame_width(self):
         curve = Curve([1, 2, 3]).opts(aspect=2, frame_width=400)
         plot = bokeh_renderer.get_plot(curve)
+        self.assertEqual(plot.state.plot_height, None)
+        self.assertEqual(plot.state.plot_width, None)
         self.assertEqual(plot.state.frame_height, 200)
         self.assertEqual(plot.state.frame_width, 400)
         self.assertEqual(plot.state.aspect_ratio, None)
@@ -413,6 +423,8 @@ class TestElementPlot(LoggingComparisonTestCase, TestBokehPlot):
     def test_element_aspect_frame_height(self):
         curve = Curve([1, 2, 3]).opts(aspect=2, frame_height=400)
         plot = bokeh_renderer.get_plot(curve)
+        self.assertEqual(plot.state.plot_height, None)
+        self.assertEqual(plot.state.plot_width, None)
         self.assertEqual(plot.state.frame_height, 400)
         self.assertEqual(plot.state.frame_width, 800)
         self.assertEqual(plot.state.aspect_ratio, None)
@@ -420,21 +432,27 @@ class TestElementPlot(LoggingComparisonTestCase, TestBokehPlot):
     def test_element_aspect_frame_width_frame_height(self):
         curve = Curve([1, 2, 3]).opts(aspect=2, frame_height=400, frame_width=400)
         plot = bokeh_renderer.get_plot(curve)
-        self.log_handler.assertContains('WARNING', "aspect value was ignored")
+        self.assertEqual(plot.state.plot_height, None)
+        self.assertEqual(plot.state.plot_width, None)
         self.assertEqual(plot.state.frame_height, 400)
         self.assertEqual(plot.state.frame_width, 400)
         self.assertEqual(plot.state.aspect_ratio, None)
+        self.log_handler.assertContains('WARNING', "aspect value was ignored")
 
     def test_element_data_aspect(self):
-        curve = Curve([0, 0.5, 1, 1.5]).opts(data_aspect=2)
+        curve = Curve([0, 0.5, 1, 1.5]).opts(data_aspect=1.5)
         plot = bokeh_renderer.get_plot(curve)
+        self.assertEqual(plot.state.plot_height, None)
+        self.assertEqual(plot.state.plot_width, None)
         self.assertEqual(plot.state.frame_height, 300)
-        self.assertEqual(plot.state.frame_width, 300)
-        self.assertEqual(plot.state.aspect_scale, 2)
+        self.assertEqual(plot.state.frame_width, 225)
+        self.assertEqual(plot.state.aspect_scale, 1.5)
 
     def test_element_data_aspect_width(self):
         curve = Curve([0, 0.5, 1, 1.5]).opts(data_aspect=2, width=400)
         plot = bokeh_renderer.get_plot(curve)
+        self.assertEqual(plot.state.plot_height, None)
+        self.assertEqual(plot.state.plot_width, None)
         self.assertEqual(plot.state.frame_height, 400)
         self.assertEqual(plot.state.frame_width, 400)
         self.assertEqual(plot.state.aspect_scale, 2)
@@ -442,6 +460,8 @@ class TestElementPlot(LoggingComparisonTestCase, TestBokehPlot):
     def test_element_data_aspect_height(self):
         curve = Curve([0, 0.5, 1, 1.5]).opts(data_aspect=2, height=400)
         plot = bokeh_renderer.get_plot(curve)
+        self.assertEqual(plot.state.plot_height, None)
+        self.assertEqual(plot.state.plot_width, None)
         self.assertEqual(plot.state.frame_height, 400)
         self.assertEqual(plot.state.frame_width, 400)
         self.assertEqual(plot.state.aspect_scale, 2)
@@ -457,6 +477,8 @@ class TestElementPlot(LoggingComparisonTestCase, TestBokehPlot):
     def test_element_data_aspect_frame_width(self):
         curve = Curve([1, 2, 3]).opts(data_aspect=2, frame_width=400)
         plot = bokeh_renderer.get_plot(curve)
+        self.assertEqual(plot.state.plot_height, None)
+        self.assertEqual(plot.state.plot_width, None)
         self.assertEqual(plot.state.frame_height, 200)
         self.assertEqual(plot.state.frame_width, 400)
         self.assertEqual(plot.state.aspect_scale, 2)
@@ -464,6 +486,8 @@ class TestElementPlot(LoggingComparisonTestCase, TestBokehPlot):
     def test_element_data_aspect_frame_height(self):
         curve = Curve([1, 2, 3]).opts(data_aspect=2, frame_height=400)
         plot = bokeh_renderer.get_plot(curve)
+        self.assertEqual(plot.state.plot_height, None)
+        self.assertEqual(plot.state.plot_width, None)
         self.assertEqual(plot.state.frame_height, 400)
         self.assertEqual(plot.state.frame_width, 800)
         self.assertEqual(plot.state.aspect_scale, 2)
@@ -471,10 +495,12 @@ class TestElementPlot(LoggingComparisonTestCase, TestBokehPlot):
     def test_element_data_aspect_frame_width_frame_height(self):
         curve = Curve([1, 2, 3]).opts(data_aspect=2, frame_height=400, frame_width=400)
         plot = bokeh_renderer.get_plot(curve)
-        self.log_handler.assertContains('WARNING', "data_aspect value was ignored")
+        self.assertEqual(plot.state.plot_height, None)
+        self.assertEqual(plot.state.plot_width, None)
         self.assertEqual(plot.state.frame_height, 400)
         self.assertEqual(plot.state.frame_width, 400)
         self.assertEqual(plot.state.aspect_scale, 1)
+        self.log_handler.assertContains('WARNING', "data_aspect value was ignored")
 
     #################################################################
     # Aspect tests

--- a/holoviews/tests/plotting/bokeh/testelementplot.py
+++ b/holoviews/tests/plotting/bokeh/testelementplot.py
@@ -524,7 +524,7 @@ class TestElementPlot(LoggingComparisonTestCase, TestBokehPlot):
         self.assertEqual(plot.state.frame_width, None)
         self.assertEqual(plot.state.sizing_mode, 'stretch_height')
 
-    def test_element_width_responsive(self):
+    def test_element_height_responsive(self):
         curve = Curve([1, 2, 3]).opts(height=400, responsive=True)
         plot = bokeh_renderer.get_plot(curve)
         self.assertEqual(plot.state.plot_height, 400)

--- a/holoviews/tests/plotting/bokeh/testelementplot.py
+++ b/holoviews/tests/plotting/bokeh/testelementplot.py
@@ -370,6 +370,266 @@ class TestElementPlot(LoggingComparisonTestCase, TestBokehPlot):
         self.assertIsInstance(toolbar.active_tap, tools.PointDrawTool)
         self.assertIsInstance(toolbar.active_drag, tools.PointDrawTool)
 
+    #################################################################
+    # Aspect tests
+    #################################################################
+
+    def test_element_aspect(self):
+        curve = Curve([1, 2, 3]).opts(aspect=2)
+        plot = bokeh_renderer.get_plot(curve)
+        self.assertEqual(plot.state.frame_height, 300)
+        self.assertEqual(plot.state.frame_width, 600)
+        self.assertEqual(plot.state.aspect_ratio, None)
+
+    def test_element_aspect_width(self):
+        curve = Curve([1, 2, 3]).opts(aspect=2, width=400)
+        plot = bokeh_renderer.get_plot(curve)
+        self.assertEqual(plot.state.frame_height, 200)
+        self.assertEqual(plot.state.frame_width, 400)
+        self.assertEqual(plot.state.aspect_ratio, None)
+
+    def test_element_aspect_height(self):
+        curve = Curve([1, 2, 3]).opts(aspect=2, height=400)
+        plot = bokeh_renderer.get_plot(curve)
+        self.assertEqual(plot.state.frame_height, 400)
+        self.assertEqual(plot.state.frame_width, 800)
+        self.assertEqual(plot.state.aspect_ratio, None)
+
+    def test_element_aspect_width_height(self):
+        curve = Curve([1, 2, 3]).opts(aspect=2, height=400, width=400)
+        plot = bokeh_renderer.get_plot(curve)
+        self.log_handler.assertContains('WARNING', "aspect value was ignored")
+        self.assertEqual(plot.state.plot_height, 400)
+        self.assertEqual(plot.state.plot_width, 400)
+        self.assertEqual(plot.state.aspect_ratio, None)
+
+    def test_element_aspect_frame_width(self):
+        curve = Curve([1, 2, 3]).opts(aspect=2, frame_width=400)
+        plot = bokeh_renderer.get_plot(curve)
+        self.assertEqual(plot.state.frame_height, 200)
+        self.assertEqual(plot.state.frame_width, 400)
+        self.assertEqual(plot.state.aspect_ratio, None)
+
+    def test_element_aspect_frame_height(self):
+        curve = Curve([1, 2, 3]).opts(aspect=2, frame_height=400)
+        plot = bokeh_renderer.get_plot(curve)
+        self.assertEqual(plot.state.frame_height, 400)
+        self.assertEqual(plot.state.frame_width, 800)
+        self.assertEqual(plot.state.aspect_ratio, None)
+
+    def test_element_aspect_frame_width_frame_height(self):
+        curve = Curve([1, 2, 3]).opts(aspect=2, frame_height=400, frame_width=400)
+        plot = bokeh_renderer.get_plot(curve)
+        self.log_handler.assertContains('WARNING', "aspect value was ignored")
+        self.assertEqual(plot.state.frame_height, 400)
+        self.assertEqual(plot.state.frame_width, 400)
+        self.assertEqual(plot.state.aspect_ratio, None)
+
+    def test_element_data_aspect(self):
+        curve = Curve([0, 0.5, 1, 1.5]).opts(data_aspect=2)
+        plot = bokeh_renderer.get_plot(curve)
+        self.assertEqual(plot.state.frame_height, 300)
+        self.assertEqual(plot.state.frame_width, 300)
+        self.assertEqual(plot.state.aspect_scale, 2)
+
+    def test_element_data_aspect_width(self):
+        curve = Curve([0, 0.5, 1, 1.5]).opts(data_aspect=2, width=400)
+        plot = bokeh_renderer.get_plot(curve)
+        self.assertEqual(plot.state.frame_height, 400)
+        self.assertEqual(plot.state.frame_width, 400)
+        self.assertEqual(plot.state.aspect_scale, 2)
+
+    def test_element_data_aspect_height(self):
+        curve = Curve([0, 0.5, 1, 1.5]).opts(data_aspect=2, height=400)
+        plot = bokeh_renderer.get_plot(curve)
+        self.assertEqual(plot.state.frame_height, 400)
+        self.assertEqual(plot.state.frame_width, 400)
+        self.assertEqual(plot.state.aspect_scale, 2)
+
+    def test_element_data_aspect_width_height(self):
+        curve = Curve([1, 2, 3]).opts(data_aspect=2, height=400, width=400)
+        plot = bokeh_renderer.get_plot(curve)
+        self.log_handler.assertContains('WARNING', "data_aspect value was ignored")
+        self.assertEqual(plot.state.plot_height, 400)
+        self.assertEqual(plot.state.plot_width, 400)
+        self.assertEqual(plot.state.aspect_scale, 1)
+
+    def test_element_data_aspect_frame_width(self):
+        curve = Curve([1, 2, 3]).opts(data_aspect=2, frame_width=400)
+        plot = bokeh_renderer.get_plot(curve)
+        self.assertEqual(plot.state.frame_height, 200)
+        self.assertEqual(plot.state.frame_width, 400)
+        self.assertEqual(plot.state.aspect_scale, 2)
+
+    def test_element_data_aspect_frame_height(self):
+        curve = Curve([1, 2, 3]).opts(data_aspect=2, frame_height=400)
+        plot = bokeh_renderer.get_plot(curve)
+        self.assertEqual(plot.state.frame_height, 400)
+        self.assertEqual(plot.state.frame_width, 800)
+        self.assertEqual(plot.state.aspect_scale, 2)
+
+    def test_element_data_aspect_frame_width_frame_height(self):
+        curve = Curve([1, 2, 3]).opts(data_aspect=2, frame_height=400, frame_width=400)
+        plot = bokeh_renderer.get_plot(curve)
+        self.log_handler.assertContains('WARNING', "data_aspect value was ignored")
+        self.assertEqual(plot.state.frame_height, 400)
+        self.assertEqual(plot.state.frame_width, 400)
+        self.assertEqual(plot.state.aspect_scale, 1)
+
+    #################################################################
+    # Aspect tests
+    #################################################################
+
+    def test_element_responsive(self):
+        curve = Curve([1, 2, 3]).opts(responsive=True)
+        plot = bokeh_renderer.get_plot(curve)
+        self.assertEqual(plot.state.plot_height, None)
+        self.assertEqual(plot.state.plot_width, None)
+        self.assertEqual(plot.state.frame_height, None)
+        self.assertEqual(plot.state.frame_width, None)
+        self.assertEqual(plot.state.sizing_mode, 'stretch_both')
+
+    def test_element_width_responsive(self):
+        curve = Curve([1, 2, 3]).opts(width=400, responsive=True)
+        plot = bokeh_renderer.get_plot(curve)
+        self.assertEqual(plot.state.plot_height, None)
+        self.assertEqual(plot.state.plot_width, 400)
+        self.assertEqual(plot.state.frame_height, None)
+        self.assertEqual(plot.state.frame_width, None)
+        self.assertEqual(plot.state.sizing_mode, 'stretch_height')
+
+    def test_element_width_responsive(self):
+        curve = Curve([1, 2, 3]).opts(height=400, responsive=True)
+        plot = bokeh_renderer.get_plot(curve)
+        self.assertEqual(plot.state.plot_height, 400)
+        self.assertEqual(plot.state.plot_width, None)
+        self.assertEqual(plot.state.frame_height, None)
+        self.assertEqual(plot.state.frame_width, None)
+        self.assertEqual(plot.state.sizing_mode, 'stretch_width')
+
+    def test_element_frame_width_responsive(self):
+        curve = Curve([1, 2, 3]).opts(frame_width=400, responsive=True)
+        plot = bokeh_renderer.get_plot(curve)
+        self.assertEqual(plot.state.plot_height, None)
+        self.assertEqual(plot.state.plot_width, None)
+        self.assertEqual(plot.state.frame_height, None)
+        self.assertEqual(plot.state.frame_width, 400)
+        self.assertEqual(plot.state.sizing_mode, 'stretch_height')
+
+    def test_element_frame_height_responsive(self):
+        curve = Curve([1, 2, 3]).opts(frame_height=400, responsive=True)
+        plot = bokeh_renderer.get_plot(curve)
+        self.assertEqual(plot.state.plot_height, None)
+        self.assertEqual(plot.state.plot_width, None)
+        self.assertEqual(plot.state.frame_height, 400)
+        self.assertEqual(plot.state.frame_width, None)
+        self.assertEqual(plot.state.sizing_mode, 'stretch_width')
+
+    def test_element_aspect_responsive(self):
+        curve = Curve([1, 2, 3]).opts(aspect=2, responsive=True)
+        plot = bokeh_renderer.get_plot(curve)
+        self.assertEqual(plot.state.plot_height, None)
+        self.assertEqual(plot.state.plot_width, None)
+        self.assertEqual(plot.state.frame_height, None)
+        self.assertEqual(plot.state.frame_width, None)
+        self.assertEqual(plot.state.sizing_mode, 'scale_both')
+
+    def test_element_aspect_width_responsive(self):
+        curve = Curve([1, 2, 3]).opts(aspect=2, width=400, responsive=True)
+        plot = bokeh_renderer.get_plot(curve)
+        self.log_handler.assertContains('WARNING', "responsive mode could not be enabled")
+        self.assertEqual(plot.state.plot_height, None)
+        self.assertEqual(plot.state.plot_width, None)
+        self.assertEqual(plot.state.frame_height, 200)
+        self.assertEqual(plot.state.frame_width, 400)
+        self.assertEqual(plot.state.sizing_mode, 'fixed')
+
+    def test_element_aspect_height_responsive(self):
+        curve = Curve([1, 2, 3]).opts(aspect=2, height=400, responsive=True)
+        plot = bokeh_renderer.get_plot(curve)
+        self.assertEqual(plot.state.frame_height, 400)
+        self.assertEqual(plot.state.frame_width, 800)
+        self.log_handler.assertContains('WARNING', "responsive mode could not be enabled")
+        self.assertEqual(plot.state.plot_height, None)
+        self.assertEqual(plot.state.plot_width, None)
+        self.assertEqual(plot.state.sizing_mode, 'fixed')
+
+    def test_element_width_height_responsive(self):
+        curve = Curve([1, 2, 3]).opts(height=400, width=400, responsive=True)
+        plot = bokeh_renderer.get_plot(curve)
+        self.assertEqual(plot.state.plot_height, 400)
+        self.assertEqual(plot.state.plot_width, 400)
+        self.log_handler.assertContains('WARNING', "responsive mode could not be enabled")
+        self.assertEqual(plot.state.frame_height, None)
+        self.assertEqual(plot.state.frame_width, None)
+        self.assertEqual(plot.state.sizing_mode, 'fixed')
+
+    def test_element_aspect_frame_width_responsive(self):
+        curve = Curve([1, 2, 3]).opts(aspect=2, frame_width=400, responsive=True)
+        plot = bokeh_renderer.get_plot(curve)
+        self.log_handler.assertContains('WARNING', "responsive mode could not be enabled")
+        self.assertEqual(plot.state.plot_height, None)
+        self.assertEqual(plot.state.plot_width, None)
+        self.assertEqual(plot.state.frame_height, 200)
+        self.assertEqual(plot.state.frame_width, 400)
+        self.assertEqual(plot.state.sizing_mode, 'fixed')
+
+    def test_element_aspect_frame_height_responsive(self):
+        curve = Curve([1, 2, 3]).opts(aspect=2, frame_height=400, responsive=True)
+        plot = bokeh_renderer.get_plot(curve)
+        self.assertEqual(plot.state.frame_height, 400)
+        self.assertEqual(plot.state.frame_width, 800)
+        self.assertEqual(plot.state.sizing_mode, 'fixed')
+        self.log_handler.assertContains('WARNING', "responsive mode could not be enabled")
+
+    def test_element_frame_width_frame_height_responsive(self):
+        curve = Curve([1, 2, 3]).opts(frame_height=400, frame_width=400, responsive=True)
+        plot = bokeh_renderer.get_plot(curve)
+        self.assertEqual(plot.state.frame_height, 400)
+        self.assertEqual(plot.state.frame_width, 400)
+        self.assertEqual(plot.state.sizing_mode, 'fixed')
+        self.log_handler.assertContains('WARNING', "responsive mode could not be enabled")
+
+    def test_element_data_aspect_responsive(self):
+        curve = Curve([0, 0.5, 1, 1.5]).opts(data_aspect=2, responsive=True)
+        plot = bokeh_renderer.get_plot(curve)
+        self.assertEqual(plot.state.aspect_ratio, 1)
+        self.assertEqual(plot.state.aspect_scale, 2)
+        self.assertEqual(plot.state.sizing_mode, 'scale_both')
+
+    def test_element_data_aspect_width_responsive(self):
+        curve = Curve([0, 0.5, 1, 1.5]).opts(data_aspect=2, width=400, responsive=True)
+        plot = bokeh_renderer.get_plot(curve)
+        self.assertEqual(plot.state.frame_height, 400)
+        self.assertEqual(plot.state.frame_width, 400)
+        self.assertEqual(plot.state.sizing_mode, 'fixed')
+        self.log_handler.assertContains('WARNING', "responsive mode could not be enabled")
+
+    def test_element_data_aspect_height_responsive(self):
+        curve = Curve([0, 0.5, 1, 1.5]).opts(data_aspect=2, height=400, responsive=True)
+        plot = bokeh_renderer.get_plot(curve)
+        self.assertEqual(plot.state.frame_height, 400)
+        self.assertEqual(plot.state.frame_width, 400)
+        self.assertEqual(plot.state.sizing_mode, 'fixed')
+        self.log_handler.assertContains('WARNING', "responsive mode could not be enabled")
+
+    def test_element_data_aspect_frame_width_responsive(self):
+        curve = Curve([1, 2, 3]).opts(data_aspect=2, frame_width=400, responsive=True)
+        plot = bokeh_renderer.get_plot(curve)
+        self.assertEqual(plot.state.frame_height, 200)
+        self.assertEqual(plot.state.frame_width, 400)
+        self.assertEqual(plot.state.sizing_mode, 'fixed')
+        self.log_handler.assertContains('WARNING', "responsive mode could not be enabled")
+
+    def test_element_data_aspect_frame_height_responsive(self):
+        curve = Curve([1, 2, 3]).opts(data_aspect=2, frame_height=400, responsive=True)
+        plot = bokeh_renderer.get_plot(curve)
+        self.assertEqual(plot.state.frame_height, 400)
+        self.assertEqual(plot.state.frame_width, 800)
+        self.assertEqual(plot.state.sizing_mode, 'fixed')
+        self.log_handler.assertContains('WARNING', "responsive mode could not be enabled")
+
+
 
 class TestColorbarPlot(TestBokehPlot):
 

--- a/holoviews/tests/plotting/bokeh/testgridplot.py
+++ b/holoviews/tests/plotting/bokeh/testgridplot.py
@@ -65,7 +65,7 @@ class TestGridPlot(TestBokehPlot):
                             for j in range(2,4) if not (i==1 and j == 2)})
         plot = bokeh_renderer.get_plot(grid)
         size = bokeh_renderer.get_size(plot.state)
-        self.assertEqual(size, (299, 293))
+        self.assertEqual(size, (311, 305))
 
     def test_grid_shared_source_synced_update(self):
         hmap = HoloMap({i: Dataset({chr(65+j): np.random.rand(i+2)

--- a/holoviews/tests/plotting/bokeh/testrenderer.py
+++ b/holoviews/tests/plotting/bokeh/testrenderer.py
@@ -76,7 +76,7 @@ class BokehRendererTest(ComparisonTestCase):
         table = Table(range(10), kdims=['x'])
         plot = self.renderer.get_plot(table+table)
         w, h = self.renderer.get_size(plot)
-        self.assertEqual((w, h), (680, 300))
+        self.assertEqual((w, h), (800, 300))
 
     def test_render_to_png(self):
         curve = Curve([])

--- a/holoviews/tests/plotting/bokeh/testrenderer.py
+++ b/holoviews/tests/plotting/bokeh/testrenderer.py
@@ -64,7 +64,7 @@ class BokehRendererTest(ComparisonTestCase):
         grid = GridSpace({(i, j): self.image1 for i in range(3) for j in range(3)})
         plot = self.renderer.get_plot(grid)
         w, h = self.renderer.get_size(plot)
-        self.assertEqual((w, h), (419, 413))
+        self.assertEqual((w, h), (437, 431))
 
     def test_get_size_table(self):
         table = Table(range(10), kdims=['x'])

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ extras_require['notebook'] = ['ipython>=5.4.0,<=7.1.1', 'notebook']
 
 # IPython Notebook + pandas + matplotlib + bokeh
 extras_require['recommended'] = extras_require['notebook'] + [
-    'pandas', 'matplotlib>=2.1', 'bokeh>=1.0.0,<1.1.0', 'panel']
+    'pandas', 'matplotlib>=2.1', 'bokeh>=1.1.0', 'panel']
 
 # Requirements to run all examples
 extras_require['examples'] = extras_require['recommended'] + [

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ extras_require['notebook'] = ['ipython>=5.4.0,<=7.1.1', 'notebook']
 
 # IPython Notebook + pandas + matplotlib + bokeh
 extras_require['recommended'] = extras_require['notebook'] + [
-    'pandas', 'matplotlib>=2.1', 'bokeh>=1.1.0', 'panel']
+    'pandas', 'matplotlib>=2.1', 'bokeh>=1.1.0dev9', 'panel']
 
 # Requirements to run all examples
 extras_require['examples'] = extras_require['recommended'] + [

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ extras_require['notebook'] = ['ipython>=5.4.0,<=7.1.1', 'notebook']
 
 # IPython Notebook + pandas + matplotlib + bokeh
 extras_require['recommended'] = extras_require['notebook'] + [
-    'pandas', 'matplotlib>=2.1', 'bokeh>=1.1.0dev9', 'panel']
+    'pandas', 'matplotlib>=2.1', 'bokeh>=1.1.0dev10', 'panel']
 
 # Requirements to run all examples
 extras_require['examples'] = extras_require['recommended'] + [


### PR DESCRIPTION
This PR achieves compatibility with the layout refactor which was merged into bokeh dev and will land in bokeh 1.1.0. It will give us control over the actual plot frame dimensions (excluding the axes, colorbars, legends) and provide control over the plot aspect.

- [x] Adds support for ``aspect`` and ``data_aspect`` in bokeh (https://github.com/pyviz/holoviews/issues/335)
- [x] Fixes support for sizing modes in bokeh
- [x] Adds lower level control over reactive layouts using min/max_width/height and width/height_policy options
- [x] Ensure data aspect is maintained when updating plot
- [x] Ensure datetime and categorical axes warn if data_aspect set
- [x] Test on bokeh server
- [x] Check no events bounce on datashade
- [x] Update documentation
- [x] Update tests
- [x] Add tests

Fixes https://github.com/pyviz/holoviews/issues/3026
Fixes https://github.com/pyviz/holoviews/issues/2992