### PR TITLE
Add an apply method to apply functions to elements

### DIFF
--- a/holoviews/core/dimension.py
+++ b/holoviews/core/dimension.py
@@ -878,7 +878,7 @@ class LabelledData(param.Parameterized):
             def apply_map(obj, **dynkwargs):
                 inner_kwargs['_in_dynamic'] = True
                 return obj.map(function, specs, clone, streams, link_inputs,
-                               **inner_kwargs)
+                               **dict(inner_kwargs, **dynkwargs))
             if not streams and isinstance(self, DynamicMap):
                 streams = self.streams
             return Dynamic(self, operation=apply_map, streams=streams,

--- a/holoviews/core/dimension.py
+++ b/holoviews/core/dimension.py
@@ -1384,8 +1384,7 @@ class Dimensioned(LabelledData):
             A new object where the function was applied to all
             contained (Nd)Overlay or Element objects.
         """
-        from .spaces import DynamicMap, HoloMap
-        from ..streams import Params
+        from .spaces import DynamicMap
         from ..util import Dynamic
 
         # Filter out instance parameters

--- a/holoviews/core/dimension.py
+++ b/holoviews/core/dimension.py
@@ -962,6 +962,7 @@ class LabelledData(param.Parameterized):
             self.param.warning("Could not unpickle custom style information.")
         d['_id'] = opts_id
         self.__dict__.update(d)
+        super(LabelledData, self).__setstate__({})
 
 
 class Dimensioned(LabelledData):
@@ -1557,6 +1558,17 @@ class ViewableTree(AttrTree, Dimensioned):
         cls._unpack_paths(vals, items, counts)
         items = cls._deduplicate_items(items)
         return items
+
+
+    def __setstate__(self, d):
+        """
+        Ensure that object does not try to reference its parent during
+        unpickling.
+        """
+        parent = d.pop('parent', None)
+        d['parent'] = None
+        super(AttrTree, self).__setstate__(d)
+        self.__dict__['parent'] = parent
 
 
     @classmethod

--- a/holoviews/core/dimension.py
+++ b/holoviews/core/dimension.py
@@ -817,7 +817,7 @@ class LabelledData(param.Parameterized):
         return accumulator
 
 
-    def map(self, function, specs='default', clone=True, streams=[],
+    def map(self, function, specs=None, clone=True, streams=[],
             link_inputs=True, **kwargs):
         """Applies a function to any matching objects.
 
@@ -861,7 +861,7 @@ class LabelledData(param.Parameterized):
         inner_kwargs = dict(kwargs, _in_dynamic=_in_dynamic)
 
         # Determine a match from the specs
-        if specs == 'default':
+        if specs is None:
             applies = isinstance(self, ViewableElement)
         else:
             if not isinstance(specs, (list, set, tuple)):
@@ -884,7 +884,7 @@ class LabelledData(param.Parameterized):
             return Dynamic(self, operation=apply_map, streams=streams,
                            link_inputs=link_inputs, kwargs=kwargs)
         elif self._deep_indexable:
-            if applies and specs == 'default':
+            if applies and specs is None:
                 return function(self, **kwargs)
 
             mapped = self.clone(shared_data=False, link=link_inputs) if clone else self

--- a/holoviews/core/operation.py
+++ b/holoviews/core/operation.py
@@ -7,7 +7,7 @@ from .dimension import ViewableElement
 from .element import Element
 from .layout import Layout
 from .overlay import NdOverlay, Overlay
-from .spaces import Callable
+from .spaces import Callable, HoloMap
 from . import util
 
 

--- a/holoviews/core/operation.py
+++ b/holoviews/core/operation.py
@@ -145,13 +145,12 @@ class Operation(param.ParameterizedFunction):
 
 
     def __call__(self, element, **kwargs):
-        params = {}
+        params = dict(kwargs)
         for k, v in kwargs.items():
             if util.is_param_method(v, has_deps=True):
-                v = v()
+                params[k] = v()
             elif isinstance(v, param.Parameter) and isinstance(v.owner, param.Parameterized):
-                v = getattr(v.owner, v.name)
-            params[k] = v
+                params[k] = getattr(v.owner, v.name)
         self.p = param.ParamOverrides(self, params)
         if isinstance(element, ViewableElement) and not self.p.dynamic:
             return self._apply(element)

--- a/holoviews/core/operation.py
+++ b/holoviews/core/operation.py
@@ -4,10 +4,10 @@ the purposes of analysis or visualization.
 """
 import param
 from .dimension import ViewableElement
-from .element import Element, HoloMap, GridSpace, NdLayout
+from .element import Element
 from .layout import Layout
 from .overlay import NdOverlay, Overlay
-from .spaces import DynamicMap, Callable
+from .spaces import Callable
 from . import util
 
 

--- a/holoviews/core/operation.py
+++ b/holoviews/core/operation.py
@@ -153,7 +153,7 @@ class Operation(param.ParameterizedFunction):
             if util.is_param_method(v, has_deps=True):
                 v = v()
             elif isinstance(v, param.Parameter) and isinstance(v.owner, param.Parameterized):
-                v = getattr(v.owner, v._attrib_name)
+                v = getattr(v.owner, v.name)
             params[k] = v
         self.p = param.ParamOverrides(self, params)
 

--- a/holoviews/core/operation.py
+++ b/holoviews/core/operation.py
@@ -152,6 +152,8 @@ class Operation(param.ParameterizedFunction):
         for k, v in kwargs.items():
             if util.is_param_method(v, has_deps=True):
                 v = v()
+            elif isinstance(v, param.Parameter) and isinstance(v.owner, param.Parameterized):
+                v = getattr(v.owner, v._attrib_name)
             params[k] = v
         self.p = param.ParamOverrides(self, params)
 

--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -1389,38 +1389,6 @@ class DynamicMap(HoloMap):
         self[key] = val
 
 
-    def map(self, map_fn, specs=None, clone=True, link_inputs=True):
-        """Map a function to all objects matching the specs
-
-        Recursively replaces elements using a map function when the
-        specs apply, by default applies to all objects, e.g. to apply
-        the function to all contained Curve objects:
-
-            dmap.map(fn, hv.Curve)
-
-        Args:
-            map_fn: Function to apply to each object
-            specs: List of specs to match
-                List of types, functions or type[.group][.label] specs
-                to select objects to return, by default applies to all
-                objects.
-            clone: Whether to clone the object or transform inplace
-
-        Returns:
-            Returns the object after the map_fn has been applied
-        """
-        deep_mapped = super(DynamicMap, self).map(map_fn, specs, clone)
-        if isinstance(deep_mapped, type(self)):
-            from ..util import Dynamic
-            def apply_map(obj, **dynkwargs):
-                return obj.map(map_fn, specs, clone)
-            dmap = Dynamic(self, operation=apply_map, streams=self.streams,
-                           link_inputs=link_inputs)
-            dmap.data = deep_mapped.data
-            return dmap
-        return deep_mapped
-
-
     def relabel(self, label=None, group=None, depth=1):
         """Clone object and apply new group and/or label.
 

--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -904,8 +904,7 @@ class DynamicMap(HoloMap):
         streams = (streams or [])
 
         # If callback is a parameterized method and watch is disabled add as stream
-        param_watch_support = util.param_version >= '1.8.0'
-        if util.is_param_method(callback) and params.get('watch', param_watch_support):
+        if util.is_param_method(callback, has_deps=True) and params.get('watch', True):
             streams.append(callback)
 
         if isinstance(callback, types.GeneratorType):

--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -1421,12 +1421,12 @@ class DynamicMap(HoloMap):
             contained (Nd)Overlay or Element objects.
         """
         if dynamic == False:
-            if any((not d.values) for d in element.kdims):
+            samples = tuple(d.values for d in self.kdims)
+            if not all(samples):
                 raise ValueError('Applying a function to a DynamicMap '
                                  'and setting dynamic=False is only '
                                  'possible if key dimensions define '
                                  'a discrete parameter space.')
-            samples = tuple(d.values for d in element.kdims)
             return HoloMap(element[samples]).apply(
                 function, streams, link_inputs, dynamic, **kwargs)
         return super(DynamicMap, self).apply(function, streams, link_inputs, dynamic, **kwargs)

--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -1427,7 +1427,7 @@ class DynamicMap(HoloMap):
                                  'and setting dynamic=False is only '
                                  'possible if key dimensions define '
                                  'a discrete parameter space.')
-            return HoloMap(element[samples]).apply(
+            return HoloMap(self[samples]).apply(
                 function, streams, link_inputs, dynamic, **kwargs)
         return super(DynamicMap, self).apply(function, streams, link_inputs, dynamic, **kwargs)
 

--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -1387,6 +1387,7 @@ class DynamicMap(HoloMap):
             self.data.pop(first_key)
         self[key] = val
 
+
     def apply(self, function, streams=[], link_inputs=True, dynamic=None, **kwargs):
         """Applies a function to all (Nd)Overlay or Element objects.
 

--- a/holoviews/core/tree.py
+++ b/holoviews/core/tree.py
@@ -32,6 +32,7 @@ class AttrTree(object):
             first.update(tree)
         return first
 
+
     def __dir__(self):
         """
         The _dir_mode may be set to 'default' or 'user' in which case

--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -1423,11 +1423,25 @@ def get_param_values(data):
     return params
 
 
-def is_param_method(obj):
+def is_param_method(obj, has_deps=False):
+    """Whether the object is a method on a parameterized object.
+
+    Args:
+       obj: Object to check
+       has_deps (boolean, optional): Check for dependencies
+          Whether to also check whether the method has been annotated
+          with param.depends
+
+    Returns:
+       A boolean value indicating whether the object is a method
+       on a Parameterized object and if enabled whether it has any
+       dependencies
     """
-    Whether the object is a method on a parameterized object.
-    """
-    return inspect.ismethod(obj) and isinstance(get_method_owner(obj), param.Parameterized)
+    parameterized = (inspect.ismethod(obj) and
+                     isinstance(get_method_owner(obj), param.Parameterized))
+    if parameterized and has_deps:
+        return getattr(obj, "_dinfo", {}).get('dependencies')
+    return parameterized
 
 
 @contextmanager

--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -1533,12 +1533,21 @@ def stream_parameters(streams, no_duplicates=True, exclude=['name']):
     If no_duplicates is enabled, a KeyError will be raised if there are
     parameter name clashes across the streams.
     """
-    param_groups = [s.contents.keys() for s in streams]
+    param_groups = []
+    for s in streams:
+        if not s.contents and isinstance(s.hashkey, dict):
+            param_groups.append(list(s.hashkey))
+        else:
+            param_groups.append(list(s.contents))
     names = [name for group in param_groups for name in group]
 
     if no_duplicates:
         clashes = sorted(set([n for n in names if names.count(n) > 1]))
-        clash_streams = [s for s in streams for c in clashes if c in s.contents]
+        clash_streams = []
+        for s in streams:
+            for c in clashes:
+                if c in s.contents or (not s.contents and isinstance(s.hashkey, dict) and c in s.hashkey):
+                    clash_streams.append(s)
         if clashes:
             clashing = ', '.join([repr(c) for c in clash_streams[:-1]])
             raise Exception('The supplied stream objects %s and %s '

--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -637,8 +637,10 @@ class Params(Stream):
         for _, group in groupby(sorted(params.items(), key=key_fn), key_fn):
             group = list(group)
             inst = [p.owner for _, p in group][0]
-            names = [p._attrib_name for _, p in group]
-            rename = {p._attrib_name: n for n, p in group}
+            if not isinstance(inst, param.Parameterized):
+                continue
+            names = [p.name for _, p in group]
+            rename = {p.name: n for n, p in group}
             streams.append(cls(inst, names, rename=rename))
         return streams
 

--- a/holoviews/tests/core/testapply.py
+++ b/holoviews/tests/core/testapply.py
@@ -1,0 +1,212 @@
+import param
+
+from holoviews.core.spaces import DynamicMap, HoloMap
+from holoviews.element import Curve
+from holoviews.element.comparison import ComparisonTestCase
+from holoviews.streams import Params, ParamMethod
+
+
+class ParamClass(param.Parameterized):
+
+    label = param.String(default='Test')
+
+    @param.depends('label')
+    def apply_label(self, obj):
+        return obj.relabel(self.label)
+
+    @param.depends('label')
+    def dynamic_label(self):
+        return self.label + '!'
+
+
+class TestApplyElement(ComparisonTestCase):
+
+    def setUp(self):
+        self.element = Curve([1, 2, 3])
+
+    def test_element_apply_simple(self):
+        applied = self.element.apply(lambda x: x.relabel('Test'))
+        self.assertEqual(applied, self.element.relabel('Test'))
+
+    def test_element_apply_with_kwarg(self):
+        applied = self.element.apply(lambda x, label: x.relabel(label), label='Test')
+        self.assertEqual(applied, self.element.relabel('Test'))
+
+    def test_element_apply_not_dynamic_with_instance_param(self):
+        pinst = ParamClass()
+        applied = self.element.apply(lambda x, label: x.relabel(label), label=pinst.param.label, dynamic=False)
+        self.assertEqual(applied, self.element.relabel('Test'))
+
+    def test_element_apply_not_dynamic_element_method(self):
+        pinst = ParamClass()
+        applied = self.element.apply(self.element.relabel, dynamic=False, label=pinst.param.label)
+        self.assertEqual(applied, self.element.relabel('Test'))
+
+    def test_element_apply_not_dynamic_with_param_method(self):
+        pinst = ParamClass()
+        applied = self.element.apply(lambda x, label: x.relabel(label), label=pinst.dynamic_label, dynamic=False)
+        self.assertEqual(applied, self.element.relabel('Test!'))
+
+    def test_element_apply_dynamic(self):
+        applied = self.element.apply(lambda x: x.relabel('Test'), dynamic=True)
+        self.assertEqual(len(applied.streams), 0)
+        self.assertEqual(applied[()], self.element.relabel('Test'))
+
+    def test_element_apply_dynamic_with_kwarg(self):
+        applied = self.element.apply(lambda x, label: x.relabel(label), dynamic=True, label='Test')
+        self.assertEqual(len(applied.streams), 0)
+        self.assertEqual(applied[()], self.element.relabel('Test'))
+
+    def test_element_apply_dynamic_element_method(self):
+        pinst = ParamClass()
+        applied = self.element.apply(self.element.relabel, label=pinst.param.label)
+
+        # Check stream
+        self.assertEqual(len(applied.streams), 1)
+        stream = applied.streams[0]
+        self.assertIsInstance(stream, Params)
+        self.assertEqual(stream.parameterized, pinst)
+        self.assertEqual(stream.parameters, ['label'])
+
+        # Check results
+        self.assertEqual(applied[()], self.element.relabel('Test'))
+        pinst.label = 'Another label'
+        self.assertEqual(applied[()], self.element.relabel('Another label'))
+
+    def test_element_apply_dynamic_with_instance_param(self):
+        pinst = ParamClass()
+        applied = self.element.apply(lambda x, label: x.relabel(label), label=pinst.param.label)
+
+        # Check stream
+        self.assertEqual(len(applied.streams), 1)
+        stream = applied.streams[0]
+        self.assertIsInstance(stream, Params)
+        self.assertEqual(stream.parameterized, pinst)
+        self.assertEqual(stream.parameters, ['label'])
+
+        # Check results
+        self.assertEqual(applied[()], self.element.relabel('Test'))
+        pinst.label = 'Another label'
+        self.assertEqual(applied[()], self.element.relabel('Another label'))
+
+    def test_element_apply_param_method_with_dependencies(self):
+        pinst = ParamClass()
+        applied = self.element.apply(pinst.apply_label)
+
+        # Check stream
+        self.assertEqual(len(applied.streams), 1)
+        stream = applied.streams[0]
+        self.assertIsInstance(stream, ParamMethod)
+        self.assertEqual(stream.parameterized, pinst)
+        self.assertEqual(stream.parameters, ['label'])
+
+        # Check results
+        self.assertEqual(applied[()], self.element.relabel('Test'))
+        pinst.label = 'Another label'
+        self.assertEqual(applied[()], self.element.relabel('Another label'))
+
+    def test_element_apply_dynamic_with_param_method(self):
+        pinst = ParamClass()
+        applied = self.element.apply(lambda x, label: x.relabel(label), label=pinst.dynamic_label)
+
+        # Check stream
+        self.assertEqual(len(applied.streams), 1)
+        stream = applied.streams[0]
+        self.assertIsInstance(stream, ParamMethod)
+        self.assertEqual(stream.parameterized, pinst)
+        self.assertEqual(stream.parameters, ['label'])
+
+        # Check result
+        self.assertEqual(applied[()], self.element.relabel('Test!'))
+        pinst.label = 'Another label'
+        self.assertEqual(applied[()], self.element.relabel('Another label!'))
+
+
+
+
+class TestApplyDynamicMap(ComparisonTestCase):
+
+    def setUp(self):
+        self.element = Curve([1, 2, 3])
+        self.dmap_unsampled = DynamicMap(lambda i: Curve([0, 1, i]), kdims='Y')
+        self.dmap = self.dmap_unsampled.redim.values(Y=[0, 1, 2])
+
+    def test_dmap_apply_not_dynamic_unsampled(self):
+        with self.assertRaises(ValueError):
+            self.dmap_unsampled.apply(lambda x: x.relabel('Test'), dynamic=False)
+        
+    def test_dmap_apply_not_dynamic(self):
+        applied = self.dmap.apply(lambda x: x.relabel('Test'), dynamic=False)
+        self.assertEqual(applied, HoloMap(self.dmap[[0, 1, 2]]).relabel('Test'))
+
+    def test_dmap_apply_not_dynamic_with_kwarg(self):
+        applied = self.dmap.apply(lambda x, label: x.relabel(label), dynamic=False, label='Test')
+        self.assertEqual(applied, HoloMap(self.dmap[[0, 1, 2]]).relabel('Test'))
+
+    def test_dmap_apply_not_dynamic_with_instance_param(self):
+        pinst = ParamClass()
+        applied = self.dmap.apply(lambda x, label: x.relabel(label), label=pinst.param.label, dynamic=False)
+        self.assertEqual(applied, HoloMap(self.dmap[[0, 1, 2]]).relabel('Test'))
+
+    def test_dmap_apply_not_dynamic_with_param_method(self):
+        pinst = ParamClass()
+        applied = self.dmap.apply(lambda x, label: x.relabel(label), label=pinst.dynamic_label, dynamic=False)
+        self.assertEqual(applied, HoloMap(self.dmap[[0, 1, 2]]).relabel('Test!'))
+
+    def test_dmap_apply_dynamic(self):
+        applied = self.dmap.apply(lambda x: x.relabel('Test'))
+        self.assertEqual(len(applied.streams), 0)
+        self.assertEqual(applied[1], self.dmap[1].relabel('Test'))
+
+    def test_dmap_apply_dynamic_with_kwarg(self):
+        applied = self.dmap.apply(lambda x, label: x.relabel(label), label='Test')
+        self.assertEqual(len(applied.streams), 0)
+        self.assertEqual(applied[1], self.dmap[1].relabel('Test'))
+
+    def test_dmap_apply_dynamic_with_instance_param(self):
+        pinst = ParamClass()
+        applied = self.dmap.apply(lambda x, label: x.relabel(label), label=pinst.param.label)
+
+        # Check stream
+        self.assertEqual(len(applied.streams), 1)
+        stream = applied.streams[0]
+        self.assertIsInstance(stream, Params)
+        self.assertEqual(stream.parameterized, pinst)
+        self.assertEqual(stream.parameters, ['label'])
+
+        # Check results
+        self.assertEqual(applied[1], self.dmap[1].relabel('Test'))
+        pinst.label = 'Another label'
+        self.assertEqual(applied[1], self.dmap[1].relabel('Another label'))
+
+    def test_dmap_apply_param_method_with_dependencies(self):
+        pinst = ParamClass()
+        applied = self.dmap.apply(pinst.apply_label)
+
+        # Check stream
+        self.assertEqual(len(applied.streams), 1)
+        stream = applied.streams[0]
+        self.assertIsInstance(stream, ParamMethod)
+        self.assertEqual(stream.parameterized, pinst)
+        self.assertEqual(stream.parameters, ['label'])
+
+        # Check results
+        self.assertEqual(applied[1], self.dmap[1].relabel('Test'))
+        pinst.label = 'Another label'
+        self.assertEqual(applied[1], self.dmap[1].relabel('Another label'))
+
+    def test_dmap_apply_dynamic_with_param_method(self):
+        pinst = ParamClass()
+        applied = self.dmap.apply(lambda x, label: x.relabel(label), label=pinst.dynamic_label)
+
+        # Check stream
+        self.assertEqual(len(applied.streams), 1)
+        stream = applied.streams[0]
+        self.assertIsInstance(stream, ParamMethod)
+        self.assertEqual(stream.parameterized, pinst)
+        self.assertEqual(stream.parameters, ['label'])
+
+        # Check result
+        self.assertEqual(applied[1], self.dmap[1].relabel('Test!'))
+        pinst.label = 'Another label'
+        self.assertEqual(applied[1], self.dmap[1].relabel('Another label!'))

--- a/holoviews/tests/core/testdynamic.py
+++ b/holoviews/tests/core/testdynamic.py
@@ -381,7 +381,7 @@ class DynamicMapOptionsTests(CustomBackendTestCase):
         dmap = dmap.options(plot_opt1='red')
         opts = Store.lookup_options('backend_1', dmap[0], 'plot')
         self.assertEqual(opts.options, {'plot_opt1': 'red'})
-    
+
     def test_dynamic_options_no_clone(self):
         dmap = DynamicMap(lambda X: TestObj(None), kdims=['X']).redim.range(X=(0,10))
         dmap.options(plot_opt1='red', clone=False)

--- a/holoviews/tests/core/testdynamic.py
+++ b/holoviews/tests/core/testdynamic.py
@@ -183,27 +183,25 @@ class DynamicMapMethods(ComparisonTestCase):
         dmap = DynamicMap(fn, kdims=[Dimension('Test', range=(10, 20))])
         self.assertEqual(dmap.select(DynamicMap, x=(5, 10))[10], fn(10))
 
-    def test_deep_map_apply_element_function(self):
+    def test_deep_apply_element_function(self):
         fn = lambda i: Curve(np.arange(i))
         dmap = DynamicMap(fn, kdims=[Dimension('Test', range=(10, 20))])
-        mapped = dmap.map(lambda x: x.clone(x.data*2), Curve)
+        mapped = dmap.apply(lambda x: x.clone(x.data*2))
         curve = fn(10)
         self.assertEqual(mapped[10], curve.clone(curve.data*2))
 
-    def test_deep_map_apply_element_function_with_kwarg(self):
+    def test_deep_apply_element_function_with_kwarg(self):
         fn = lambda i: Curve(np.arange(i))
         dmap = DynamicMap(fn, kdims=[Dimension('Test', range=(10, 20))])
-        mapped = dmap.map(lambda x, label: x.relabel(label), label='New label')
-        curve = fn(10)
-        self.assertEqual(mapped[10], curve.relabel('New label'))
+        mapped = dmap.apply(lambda x, label: x.relabel(label), label='New label')
+        self.assertEqual(mapped[10], fn(10).relabel('New label'))
 
     def test_deep_map_apply_element_function_with_stream_kwarg(self):
         stream = Stream.define('Test', label='New label')()
         fn = lambda i: Curve(np.arange(i))
         dmap = DynamicMap(fn, kdims=[Dimension('Test', range=(10, 20))])
-        mapped = dmap.map(lambda x, label: x.relabel(label), streams=[stream])
-        curve = fn(10)
-        self.assertEqual(mapped[10], curve.relabel('New label'))
+        mapped = dmap.apply(lambda x, label: x.relabel(label), streams=[stream])
+        self.assertEqual(mapped[10], fn(10).relabel('New label'))
 
     def test_deep_map_apply_parameterized_method_with_stream_kwarg(self):
         class Test(param.Parameterized):
@@ -217,13 +215,13 @@ class DynamicMapMethods(ComparisonTestCase):
         test = Test()
         fn = lambda i: Curve(np.arange(i))
         dmap = DynamicMap(fn, kdims=[Dimension('Test', range=(10, 20))])
-        mapped = dmap.map(lambda x, label: x.relabel(label), label=test.value)
+        mapped = dmap.apply(lambda x, label: x.relabel(label), label=test.value)
         curve = fn(10)
         self.assertEqual(mapped[10], curve.relabel('Label'))
         test.label = 'new label'
         self.assertEqual(mapped[10], curve.relabel('New Label'))
 
-    def test_deep_map_apply_parameterized_method_with_dependency(self):
+    def test_deep_apply_parameterized_method_with_dependency(self):
         class Test(param.Parameterized):
 
             label = param.String(default='label')
@@ -235,13 +233,13 @@ class DynamicMapMethods(ComparisonTestCase):
         test = Test()
         fn = lambda i: Curve(np.arange(i))
         dmap = DynamicMap(fn, kdims=[Dimension('Test', range=(10, 20))])
-        mapped = dmap.map(test.relabel)
+        mapped = dmap.apply(test.relabel)
         curve = fn(10)
         self.assertEqual(mapped[10], curve.relabel('Label'))
         test.label = 'new label'
         self.assertEqual(mapped[10], curve.relabel('New Label'))
 
-    def test_deep_map_apply_parameterized_method_with_dependency_and_static_kwarg(self):
+    def test_deep_apply_parameterized_method_with_dependency_and_static_kwarg(self):
         class Test(param.Parameterized):
 
             label = param.String(default='label')
@@ -253,7 +251,7 @@ class DynamicMapMethods(ComparisonTestCase):
         test = Test()
         fn = lambda i: Curve(np.arange(i))
         dmap = DynamicMap(fn, kdims=[Dimension('Test', range=(10, 20))])
-        mapped = dmap.map(test.relabel, group='Group')
+        mapped = dmap.apply(test.relabel, group='Group')
         curve = fn(10)
         self.assertEqual(mapped[10], curve.relabel('Label', 'Group'))
         test.label = 'new label'
@@ -264,6 +262,14 @@ class DynamicMapMethods(ComparisonTestCase):
         dmap = DynamicMap(fn, kdims=[Dimension('Test', range=(10, 20))])
         dmap[10]
         mapped = dmap.map(lambda x: Scatter(x), Curve)
+        area = mapped[11]
+        self.assertEqual(area, Scatter(fn(11)))
+
+    def test_deep_apply_transform_element_type(self):
+        fn = lambda i: Curve(np.arange(i))
+        dmap = DynamicMap(fn, kdims=[Dimension('Test', range=(10, 20))])
+        dmap[10]
+        mapped = dmap.apply(lambda x: Scatter(x))
         area = mapped[11]
         self.assertEqual(area, Scatter(fn(11)))
 

--- a/holoviews/util/__init__.py
+++ b/holoviews/util/__init__.py
@@ -8,7 +8,7 @@ from pyviz_comms import extension as _pyviz_extension
 from ..core import DynamicMap, HoloMap, Dimensioned, ViewableElement, StoreOptions, Store
 from ..core.options import options_policy, Keywords, Options
 from ..core.operation import Operation
-from ..core.util import Aliases, basestring, merge_options_to_dict  # noqa (API import)
+from ..core.util import Aliases, basestring, merge_options_to_dict, OrderedDict  # noqa (API import)
 from ..core.operation import OperationCallable
 from ..core.spaces import Callable
 from ..core import util
@@ -835,7 +835,7 @@ class Dynamic(param.ParameterizedFunction):
             dmap = map_obj.clone(callback=callback, shared_data=self.p.shared_data,
                                  streams=streams)
             if self.p.shared_data:
-                dmap.data = OrderedDict([(k, callback.callable(*key))
+                dmap.data = OrderedDict([(k, callback.callable(*k))
                                           for k, v in dmap.data])
         else:
             dmap = self._make_dynamic(map_obj, callback, streams)

--- a/holoviews/util/__init__.py
+++ b/holoviews/util/__init__.py
@@ -12,7 +12,7 @@ from ..core.util import Aliases, basestring, merge_options_to_dict, OrderedDict 
 from ..core.operation import OperationCallable
 from ..core.spaces import Callable
 from ..core import util
-from ..streams import Stream
+from ..streams import Stream, Params
 from .settings import OutputSettings, list_formats, list_backends
 
 Store.output_settings = OutputSettings
@@ -865,12 +865,15 @@ class Dynamic(param.ParameterizedFunction):
                     stream.update(**{reverse.get(k, k): v for k, v in updates.items()})
             streams.append(stream)
 
+        params = {k: v for k, v in self.p.kwargs.items() if isinstance(v, param.Parameter)
+                  and isinstance(v.owner, param.Parameterized)}
+        streams += Params.from_params(params)
+
         # Add any keyword arguments which are parameterized methods
         # with dependencies as streams
         for value in self.p.kwargs.values():
-            if not util.is_param_method(value, has_deps=True):
-                continue
-            streams.append(value)
+            if util.is_param_method(value, has_deps=True):
+                streams.append(value)
 
         # Inherit dimensioned streams
         if isinstance(map_obj, DynamicMap):

--- a/holoviews/util/__init__.py
+++ b/holoviews/util/__init__.py
@@ -834,6 +834,9 @@ class Dynamic(param.ParameterizedFunction):
         if isinstance(map_obj, DynamicMap):
             dmap = map_obj.clone(callback=callback, shared_data=self.p.shared_data,
                                  streams=streams)
+            if self.p.shared_data:
+                dmap.data = OrderedDict([(k, callback.callable(*key))
+                                          for k, v in dmap.data])
         else:
             dmap = self._make_dynamic(map_obj, callback, streams)
         return dmap
@@ -851,7 +854,7 @@ class Dynamic(param.ParameterizedFunction):
         for stream in self.p.streams:
             if inspect.isclass(stream) and issubclass(stream, Stream):
                 stream = stream()
-            elif not isinstance(stream, Stream):
+            elif not (isinstance(stream, Stream) or util.is_param_method(stream)):
                 raise ValueError('Streams must be Stream classes or instances')
             if isinstance(self.p.operation, Operation):
                 updates = {k: self.p.operation.p.get(k) for k, v in stream.contents.items()

--- a/holoviews/util/__init__.py
+++ b/holoviews/util/__init__.py
@@ -855,7 +855,8 @@ class Dynamic(param.ParameterizedFunction):
             if inspect.isclass(stream) and issubclass(stream, Stream):
                 stream = stream()
             elif not (isinstance(stream, Stream) or util.is_param_method(stream)):
-                raise ValueError('Streams must be Stream classes or instances')
+                raise ValueError('Streams must be Stream classes or instances, found %s type' %
+                                 type(stream).__name__)
             if isinstance(self.p.operation, Operation):
                 updates = {k: self.p.operation.p.get(k) for k, v in stream.contents.items()
                            if v is None and k in self.p.operation.p}
@@ -863,14 +864,23 @@ class Dynamic(param.ParameterizedFunction):
                     reverse = {v: k for k, v in stream._rename.items()}
                     stream.update(**{reverse.get(k, k): v for k, v in updates.items()})
             streams.append(stream)
+
+        # Add any keyword arguments which are parameterized methods
+        # with dependencies as streams
+        for value in self.p.kwargs.values():
+            if not util.is_param_method(value, has_deps=True):
+                continue
+            streams.append(value)
+
+        # Inherit dimensioned streams
         if isinstance(map_obj, DynamicMap):
             dim_streams = util.dimensioned_streams(map_obj)
             streams = list(util.unique_iterator(streams + dim_streams))
 
         # If callback is a parameterized method and watch is disabled add as stream
-        param_watch_support = util.param_version >= '1.8.0' and watch
-        if util.is_param_method(self.p.operation) and param_watch_support:
+        if util.is_param_method(self.p.operation, has_deps=True) and watch:
             streams.append(self.p.operation)
+
         valid, invalid = Stream._process_streams(streams)
         if invalid:
             msg = ('The supplied streams list contains objects that '
@@ -878,15 +888,22 @@ class Dynamic(param.ParameterizedFunction):
             raise TypeError(msg.format(objs = ', '.join('%r' % el for el in invalid)))
         return valid
 
-
-    def _process(self, element, key=None):
+    def _process(self, element, key=None, kwargs={}):
         if isinstance(self.p.operation, Operation):
-            kwargs = {k: v for k, v in self.p.kwargs.items()
+            kwargs = {k: v for k, v in kwargs.items()
                       if k in self.p.operation.params()}
             return self.p.operation.process_element(element, key, **kwargs)
         else:
-            return self.p.operation(element, **self.p.kwargs)
+            return self.p.operation(element, **kwargs)
 
+    def _eval_kwargs(self):
+        """Evaluates any parameterized methods in the kwargs"""
+        evaled_kwargs = {}
+        for k, v in self.p.kwargs.items():
+            if util.is_param_method(v):
+                v = v()
+            evaled_kwargs[k] = v
+        return evaled_kwargs
 
     def _dynamic_operation(self, map_obj):
         """
@@ -895,13 +912,13 @@ class Dynamic(param.ParameterizedFunction):
         """
         if not isinstance(map_obj, DynamicMap):
             def dynamic_operation(*key, **kwargs):
-                self.p.kwargs.update(kwargs)
+                kwargs = dict(self._eval_kwargs(), **kwargs)
                 obj = map_obj[key] if isinstance(map_obj, HoloMap) else map_obj
-                return self._process(obj, key)
+                return self._process(obj, key, kwargs)
         else:
             def dynamic_operation(*key, **kwargs):
-                self.p.kwargs.update(kwargs)
-                return self._process(map_obj[key], key)
+                kwargs = dict(self._eval_kwargs(), **kwargs)
+                return self._process(map_obj[key], key, kwargs)
         if isinstance(self.p.operation, Operation):
             return OperationCallable(dynamic_operation, inputs=[map_obj],
                                      link_inputs=self.p.link_inputs,


### PR DESCRIPTION
This PR implements the outcome of our API discussion to provide a more convenient API than ``hv.util.Dynamic``. The main changes are twofold:

* ``.apply`` now defaults to ViewableElement for its spec keyword, which means it behaves exactly like an Operation
* Added support for supplying streams and keywords to ``.apply``, which make it behave like ``hv.util.Dynamic``, i.e. it provides support for chaining dynamic operations, but also making existing objects become dynamic if there is a stream or parameter dependency declared.

- Supercedes #3473 
- [x] Add support for dynamic parameters
- [x] Add unit tests