### PR TITLE
Retain Element._plot_id on redim

### DIFF
--- a/holoviews/core/dimension.py
+++ b/holoviews/core/dimension.py
@@ -209,7 +209,6 @@ class redim(object):
             if self.mode != 'dynamic' and not matches:
                 return redimmed
 
-
         kdims = self.replace_dimensions(parent.kdims, dimensions)
         vdims = self.replace_dimensions(parent.vdims, dimensions)
         zipped_dims = zip(parent.kdims+parent.vdims, kdims+vdims)
@@ -219,7 +218,12 @@ class redim(object):
             data = parent.data
             if renames:
                 data = parent.interface.redim(parent, renames)
-            return parent.clone(data, kdims=kdims, vdims=vdims)
+            clone = parent.clone(data, kdims=kdims, vdims=vdims)
+            if self.parent.dimensions(label='name') == clone.dimensions(label='name'):
+                # Ensure that plot_id is inherited as long as dimension
+                # name does not change
+                clone._plot_id = self.parent._plot_id
+            return clone
 
         if self.mode != 'dynamic':
             return redimmed.clone(kdims=kdims, vdims=vdims)


### PR DESCRIPTION
As long as the data itself does not change ``redim`` should not change the plot_id and therefore break links between plots. This PR checks whether the dimension names change before restoring the previous plot_id on a redim, since the only redim change that necessitates a change to the data is a change in the dimension names.

- [x] Fixes https://github.com/pyviz/holoviews/issues/3458