### PR TITLE
Ensure Image coordinates are rectilinear

### DIFF
--- a/holoviews/tests/element/testimage.py
+++ b/holoviews/tests/element/testimage.py
@@ -76,4 +76,10 @@ class TestImage(LoggingComparisonTestCase):
         img = Image({'vals':vals, 'xs':xs, 'ys':ys}, ['xs','ys'], 'vals', rtol=10e-3)
         self.assertEqual(img.clone().rtol, 10e-3)
 
-
+    def test_image_curvilinear_coords_error(self):
+        x = np.arange(-1, 1, 0.1)
+        y = np.arange(-1, 1, 0.1)
+        X, Y = np.meshgrid(x, y)
+        Z = np.sqrt(X**2 + Y**2) * np.cos(X)
+        with self.assertRaises(ValueError):
+            Image((X, Y, Z))


### PR DESCRIPTION
Image used to implicitly allow curvilinear coordinates, this PR ensures it errors in this case and recommends supplying 1D coordinate arrays or using QuadMesh.

- [x] Fixes https://github.com/pyviz/holoviews/issues/3465