### PR TITLE
Fixed Param stream memoization

### DIFF
--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -4,7 +4,6 @@ generate and respond to events, originating either in Python on the
 server-side or in Javascript in the Jupyter notebook (client-side).
 """
 
-import uuid
 import weakref
 from numbers import Number
 from collections import defaultdict
@@ -641,7 +640,7 @@ class Params(Stream):
             self._events = []
 
     def _on_trigger(self):
-        if any(e.type == 'triggered' for e in events):
+        if any(e.type == 'triggered' for e in self._events):
             self._memoize_counter += 1
 
     @property

--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -633,8 +633,10 @@ class Params(Stream):
         return mapping
 
     def _watcher(self, *events):
-        self._memoize_counter += 1
         self.trigger([self])
+
+    def _trigger(self):
+        self._memoize_counter += 1
 
     @property
     def hashkey(self):

--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -157,12 +157,12 @@ class Stream(param.Parameterized):
                 subscriber(**dict(union))
 
         for stream in streams:
-            stream._trigger()
+            stream._on_trigger()
             with util.disable_constant(stream):
                 if stream.transient:
                     stream.reset()
 
-    def _trigger(self):
+    def _on_trigger(self):
         """Called when a stream has been triggered"""
 
     @classmethod
@@ -437,7 +437,7 @@ class Pipe(Stream):
         """
         self.event(data=data)
 
-    def _trigger(self):
+    def _on_trigger(self):
         self._memoize_counter += 1
 
     @property
@@ -635,7 +635,7 @@ class Params(Stream):
     def _watcher(self, *events):
         self.trigger([self])
 
-    def _trigger(self):
+    def _on_trigger(self):
         self._memoize_counter += 1
 
     @property

--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -618,6 +618,7 @@ class Params(Stream):
             parameters = [p for p in parameterized.params() if p != 'name']
         super(Params, self).__init__(parameterized=parameterized, parameters=parameters, **params)
         self._memoize_counter = 0
+        self._events = []
         if watch:
             self.parameterized.param.watch(self._watcher, self.parameters)
 
@@ -631,10 +632,17 @@ class Params(Stream):
         return mapping
 
     def _watcher(self, *events):
-        self.trigger([self])
+        try:
+            self._events = list(events)
+            self.trigger([self])
+        except:
+            raise
+        finally:
+            self._events = []
 
     def _on_trigger(self):
-        self._memoize_counter += 1
+        if any(e.type == 'triggered' for e in events):
+            self._memoize_counter += 1
 
     @property
     def hashkey(self):

--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -427,7 +427,6 @@ class Pipe(Stream):
 
     def __init__(self, data=None, memoize=False, **params):
         super(Pipe, self).__init__(data=data, **params)
-        self._memoize_key = '_memoize_counter_' + uuid.uuid4().hex
         self._memoize_counter = 0
 
     def send(self, data):
@@ -442,7 +441,7 @@ class Pipe(Stream):
 
     @property
     def hashkey(self):
-        return {self._memoize_key: self._memoize_counter}
+        return {'_memoize_key': self._memoize_counter}
 
 
 class Buffer(Pipe):
@@ -618,7 +617,6 @@ class Params(Stream):
         if parameters is None:
             parameters = [p for p in parameterized.params() if p != 'name']
         super(Params, self).__init__(parameterized=parameterized, parameters=parameters, **params)
-        self._memoize_key = '_memoize_counter_' + uuid.uuid4().hex
         self._memoize_counter = 0
         if watch:
             self.parameterized.param.watch(self._watcher, self.parameters)
@@ -644,7 +642,7 @@ class Params(Stream):
                    if k in self.parameters}
         hashkey = {self._rename.get(k, k): v for (k, v) in hashkey.items()
                    if self._rename.get(k, True) is not None}
-        hashkey[self._memoize_key] = self._memoize_counter
+        hashkey['_memoize_key'] = self._memoize_counter
         return hashkey
 
     def reset(self):

--- a/holoviews/tests/teststreams.py
+++ b/holoviews/tests/teststreams.py
@@ -256,7 +256,8 @@ class TestParamsStream(ComparisonTestCase):
         values = []
         def subscriber(**kwargs):
             values.append(kwargs)
-            self.assertEqual(set(stream.hashkey), {'action', '_memoize_counter'})
+            self.assertEqual(set(stream.hashkey),
+                             {'action', stream._memoize_key})
 
         stream.add_subscriber(subscriber)
         inner.action(inner)
@@ -270,7 +271,8 @@ class TestParamsStream(ComparisonTestCase):
         values = []
         def subscriber(**kwargs):
             values.append(kwargs)
-            self.assertEqual(set(stream.hashkey), {'action', 'x', '_memoize_counter'})
+            self.assertEqual(set(stream.hashkey),
+                             {'action', 'x', stream._memoize_key})
 
         stream.add_subscriber(subscriber)
         inner.action(inner)
@@ -405,7 +407,8 @@ class TestParamMethodStream(ComparisonTestCase):
         values = []
         def subscriber(**kwargs):
             values.append(kwargs)
-            self.assertEqual(set(stream.hashkey), {'action', '_memoize_counter'})
+            self.assertEqual(set(stream.hashkey),
+                             {'action', stream._memoize_key})
 
         stream.add_subscriber(subscriber)
         inner.action(inner)
@@ -423,7 +426,8 @@ class TestParamMethodStream(ComparisonTestCase):
         values = []
         def subscriber(**kwargs):
             values.append(kwargs)
-            self.assertEqual(set(stream.hashkey), {'action', 'x', '_memoize_counter'})
+            self.assertEqual(set(stream.hashkey),
+                             {'action', 'x', stream._memoize_key})
 
         stream.add_subscriber(subscriber)
         stream.add_subscriber(lambda **kwargs: dmap[()])

--- a/holoviews/tests/teststreams.py
+++ b/holoviews/tests/teststreams.py
@@ -256,11 +256,26 @@ class TestParamsStream(ComparisonTestCase):
         values = []
         def subscriber(**kwargs):
             values.append(kwargs)
-            self.assertEqual(list(stream.hashkey), ['hash'])
+            self.assertEqual(set(stream.hashkey), {'action', '_memoize_counter'})
 
         stream.add_subscriber(subscriber)
         inner.action(inner)
         self.assertEqual(values, [{'action': inner.action}])
+
+    def test_param_stream_memoization(self):
+        inner = self.inner_action()
+        stream = Params(inner, ['action', 'x'])
+        self.assertEqual(set(stream.parameters), {'action', 'x'})
+
+        values = []
+        def subscriber(**kwargs):
+            values.append(kwargs)
+            self.assertEqual(set(stream.hashkey), {'action', 'x', '_memoize_counter'})
+
+        stream.add_subscriber(subscriber)
+        inner.action(inner)
+        inner.x = 0
+        self.assertEqual(values, [{'action': inner.action, 'x': 0}])
 
         
 
@@ -285,6 +300,11 @@ class TestParamMethodStream(ComparisonTestCase):
             @param.depends('action')
             def action_method(self):
                 pass
+
+            @param.depends('action', 'x')
+            def action_number_method(self):
+                self.count += 1
+                return Points([])
 
             @param.depends('y')
             def op_method(self, obj):
@@ -385,12 +405,35 @@ class TestParamMethodStream(ComparisonTestCase):
         values = []
         def subscriber(**kwargs):
             values.append(kwargs)
-            self.assertEqual(list(stream.hashkey), ['hash'])
+            self.assertEqual(set(stream.hashkey), {'action', '_memoize_counter'})
 
         stream.add_subscriber(subscriber)
         inner.action(inner)
         self.assertEqual(values, [{}])
-    
+
+    def test_dynamicmap_param_action_number_method_memoizes(self):
+        inner = self.inner()
+        dmap = DynamicMap(inner.action_number_method)
+        self.assertEqual(len(dmap.streams), 1)
+        stream = dmap.streams[0]
+        self.assertEqual(set(stream.parameters), {'action', 'x'})
+        self.assertIsInstance(stream, ParamMethod)
+        self.assertEqual(stream.contents, {})
+
+        values = []
+        def subscriber(**kwargs):
+            values.append(kwargs)
+            self.assertEqual(set(stream.hashkey), {'action', 'x', '_memoize_counter'})
+
+        stream.add_subscriber(subscriber)
+        stream.add_subscriber(lambda **kwargs: dmap[()])
+        inner.action(inner)
+        self.assertEqual(values, [{}])
+        self.assertEqual(inner.count, 1)
+        inner.x = 0
+        self.assertEqual(values, [{}])
+        self.assertEqual(inner.count, 1)
+
     def test_dynamicmap_param_method_dynamic_operation(self):
         inner = self.inner()
         dmap = DynamicMap(inner.method)

--- a/holoviews/tests/teststreams.py
+++ b/holoviews/tests/teststreams.py
@@ -257,7 +257,7 @@ class TestParamsStream(ComparisonTestCase):
         def subscriber(**kwargs):
             values.append(kwargs)
             self.assertEqual(set(stream.hashkey),
-                             {'action', stream._memoize_key})
+                             {'action', '_memoize_key'})
 
         stream.add_subscriber(subscriber)
         inner.action(inner)
@@ -272,7 +272,7 @@ class TestParamsStream(ComparisonTestCase):
         def subscriber(**kwargs):
             values.append(kwargs)
             self.assertEqual(set(stream.hashkey),
-                             {'action', 'x', stream._memoize_key})
+                             {'action', 'x', '_memoize_key'})
 
         stream.add_subscriber(subscriber)
         inner.action(inner)
@@ -408,7 +408,7 @@ class TestParamMethodStream(ComparisonTestCase):
         def subscriber(**kwargs):
             values.append(kwargs)
             self.assertEqual(set(stream.hashkey),
-                             {'action', stream._memoize_key})
+                             {'action', '_memoize_key'})
 
         stream.add_subscriber(subscriber)
         inner.action(inner)
@@ -427,7 +427,7 @@ class TestParamMethodStream(ComparisonTestCase):
         def subscriber(**kwargs):
             values.append(kwargs)
             self.assertEqual(set(stream.hashkey),
-                             {'action', 'x', stream._memoize_key})
+                             {'action', 'x', '_memoize_key'})
 
         stream.add_subscriber(subscriber)
         stream.add_subscriber(lambda **kwargs: dmap[()])


### PR DESCRIPTION
This fixes a bug in `Param` and `Pipe` stream memoization. In order to support memoization when a hash is either very expensive to compute or when there is no parameter value to hash on we previously introduced a random hashkey which is returned when a Stream is triggering. This works fine in ensuring memoization is disabled for that particular call but any subsequent events triggered by another stream will receive a new hashkey, which disables memoization. Instead of using a random value this PR therefore introduces a `_memoize_counter` which is incremented whenever an event is triggered on these streams, which means subsequent events receive a consistent value to hash on.