### PR TITLE
Enable the use of xlim parameter for timeseries plots

### DIFF
--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -746,7 +746,7 @@ class GenericElementPlot(DimensionedPlot):
         An explicit override of the y-axis label, if set takes precedence
         over the dimension label.""")
 
-    xlim = param.NumericTuple(default=(np.nan, np.nan), length=2, doc="""
+    xlim = param.Tuple(default=(np.nan, np.nan), length=2, doc="""
        User-specified x-axis range limits for the plot, as a tuple (low,high).
        If specified, takes precedence over data and dimension ranges.""")
 

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -750,11 +750,11 @@ class GenericElementPlot(DimensionedPlot):
        User-specified x-axis range limits for the plot, as a tuple (low,high).
        If specified, takes precedence over data and dimension ranges.""")
 
-    ylim = param.NumericTuple(default=(np.nan, np.nan), length=2, doc="""
+    ylim = param.Tuple(default=(np.nan, np.nan), length=2, doc="""
        User-specified x-axis range limits for the plot, as a tuple (low,high).
        If specified, takes precedence over data and dimension ranges.""")
 
-    zlim = param.NumericTuple(default=(np.nan, np.nan), length=2, doc="""
+    zlim = param.Tuple(default=(np.nan, np.nan), length=2, doc="""
        User-specified z-axis range limits for the plot, as a tuple (low,high).
        If specified, takes precedence over data and dimension ranges.""")
 


### PR DESCRIPTION
Hey,

Since `xlim` parameter was a `NumericTuple` it was not possible to set it using dates for timeseries plot. Changing it to `Tuple` makes it more flexible.