### PR TITLE
Added an 'output' options group

### DIFF
--- a/holoviews/core/dimension.py
+++ b/holoviews/core/dimension.py
@@ -1399,7 +1399,7 @@ class Dimensioned(LabelledData):
             if kwargs:
                 raise ValueError('Please specify a list of option objects, or kwargs, but not both')
             options = args[0]
-        elif args and kwargs:
+        elif args and [k for k in kwargs.keys() if k != 'backend']:
             raise ValueError("Options must be defined in one of two formats. "
                              "Either supply keywords defining the options for "
                              "the current object, e.g. obj.options(cmap='viridis'), "

--- a/holoviews/core/dimension.py
+++ b/holoviews/core/dimension.py
@@ -18,7 +18,7 @@ import param
 import numpy as np
 
 from . import util
-from .options import Store, Opts, cleanup_custom_options
+from .options import Store, Opts, Options, cleanup_custom_options
 from .pprint import PrettyPrinter
 from .tree import AttrTree
 from .util import basestring, OrderedDict, bytes_to_unicode, unicode
@@ -1406,6 +1406,8 @@ class Dimensioned(LabelledData):
                              "or explicitly define the type, e.g. "
                              "obj.options({'Image': {'cmap': 'viridis'}}). "
                              "Supplying both formats is not supported.")
+        elif args and isinstance(args[0], dict):
+            options = [Options(spec, **kws) for spec,kws in args[0].items()]
         elif args:
             options = list(args)
         elif kwargs:

--- a/holoviews/core/dimension.py
+++ b/holoviews/core/dimension.py
@@ -1388,7 +1388,7 @@ class Dimensioned(LabelledData):
         Returns:
             Returns the cloned object with the options applied
         """
-        backend = kwargs.pop('backend', None)
+        backend = kwargs.get('backend', None)
         clone = kwargs.pop('clone', True)
 
         if len(args) == 0 and len(kwargs)==0:
@@ -1413,11 +1413,16 @@ class Dimensioned(LabelledData):
 
         from ..util import opts
         if options is None:
-            expanded = {}
+            expanded_backends = [(backend, {})]
+        elif isinstance(options, list): # assuming a flat list of Options objects
+            expanded_backends = opts._expand_by_backend(options, backend)
         else:
-            expanded = opts._expand_options(options, backend)
-        return self.opts(expanded, backend=backend, clone=clone)
+            expanded_backends = [(backend, opts._expand_options(options, backend))]
 
+        obj = self
+        for backend, expanded in expanded_backends:
+            obj = obj.opts(expanded, backend=backend, clone=clone)
+        return obj
 
     def _repr_mimebundle_(self, include=None, exclude=None):
         """

--- a/holoviews/core/dimension.py
+++ b/holoviews/core/dimension.py
@@ -1421,7 +1421,7 @@ class Dimensioned(LabelledData):
 
         obj = self
         for backend, expanded in expanded_backends:
-            obj = obj.opts(expanded, backend=backend, clone=clone)
+            obj = obj.opts._dispatch_opts(expanded, backend=backend, clone=clone)
         return obj
 
     def _repr_mimebundle_(self, include=None, exclude=None):

--- a/holoviews/core/dimension.py
+++ b/holoviews/core/dimension.py
@@ -1406,7 +1406,11 @@ class Dimensioned(LabelledData):
                              "or explicitly define the type, e.g. "
                              "obj.options({'Image': {'cmap': 'viridis'}}). "
                              "Supplying both formats is not supported.")
-        elif args and isinstance(args[0], dict):
+        elif args and all(isinstance(el, dict) for el in args):
+            if len(args) > 1:
+                self.warning('Only a single dictionary can be passed '
+                             'as a positional argument. Only processing '
+                             'the first dictionary')
             options = [Options(spec, **kws) for spec,kws in args[0].items()]
         elif args:
             options = list(args)

--- a/holoviews/core/options.py
+++ b/holoviews/core/options.py
@@ -1461,10 +1461,10 @@ class Store(object):
             plot_opts =  Keywords(plot_opts,  target=view_class.__name__)
             style_opts = Keywords(style_opts, target=view_class.__name__)
 
-            opt_groups = {'plot': Options(allowed_keywords=plot_opts)}
+            opt_groups = {'plot':   Options(allowed_keywords=plot_opts),
+                          'output': Options(allowed_keywords=['backend'])}
             if not isinstance(view_class, CompositeOverlay) or hasattr(plot, 'style_opts'):
                  opt_groups.update({'style': Options(allowed_keywords=style_opts),
-                                    'output':Options(allowed_keywords=['backend']),
                                     'norm':  Options(framewise=False, axiswise=False,
                                                      allowed_keywords=['framewise',
                                                                        'axiswise'])})

--- a/holoviews/core/options.py
+++ b/holoviews/core/options.py
@@ -235,18 +235,6 @@ class Opts(object):
             from ..util import opts
             if options is not None:
                 kwargs['options'] = options
-
-                if 'backend' in kwargs: # Backend kwarg overriding the spec
-                    for spec in options.values():
-                        if 'output' in spec:
-                            spec['output']['backend'] = kwargs['backend'] # Override
-                else:
-                    for spec in options.values():
-                        if 'output' in spec:
-                            # Set the kwarg from the output group
-                            kwargs['backend']= spec['output']['backend']
-
-            # Should not have to do clone=False
             return opts.apply_groups(self._obj, **dict(kwargs, **new_kwargs))
 
         kwargs['clone'] = False if clone is None else clone

--- a/holoviews/core/options.py
+++ b/holoviews/core/options.py
@@ -581,7 +581,7 @@ class Options(param.Parameterized):
        skipping over invalid keywords or not. May only be specified at
        the class level.""")
 
-    _option_groups = ['style', 'plot', 'norm']
+    _option_groups = ['style', 'plot', 'norm', 'output']
 
     def __init__(self, key=None, allowed_keywords=[], merge_keywords=True, max_cycles=None, **kwargs):
 

--- a/holoviews/core/options.py
+++ b/holoviews/core/options.py
@@ -235,8 +235,19 @@ class Opts(object):
             from ..util import opts
             if options is not None:
                 kwargs['options'] = options
-            # Should not have to do clone=False and output group missing
-            return opts.apply_groups(self._obj, **dict(kwargs, clone=False, **new_kwargs))
+
+                if 'backend' in kwargs: # Backend kwarg overriding the spec
+                    for spec in options.values():
+                        if 'output' in spec:
+                            spec['output']['backend'] = kwargs['backend'] # Override
+                else:
+                    for spec in options.values():
+                        if 'output' in spec:
+                            # Set the kwarg from the output group
+                            kwargs['backend']= spec['output']['backend']
+
+            # Should not have to do clone=False
+            return opts.apply_groups(self._obj, **dict(kwargs, **new_kwargs))
 
         kwargs['clone'] = False if clone is None else clone
         return self._obj.options(*args, **kwargs)

--- a/holoviews/core/options.py
+++ b/holoviews/core/options.py
@@ -159,6 +159,18 @@ class Opts(object):
             Returns the object or a clone with the options applied
         """
         if self._mode is None:
+            apply_groups, _, _ = deprecated_opts_signature(args, kwargs)
+            if apply_groups and config.future_deprecations:
+                msg = ("Calling the .opts method with options broken down by options "
+                       "group (i.e. separate plot, style and norm groups) is deprecated. "
+                       "Use the .options method converting to the simplified format "
+                       "instead or use hv.opts.apply_groups for backward compatibility.")
+                param.main.warning(msg)
+
+        return self._dispatch_opts( *args, **kwargs)
+
+    def _dispatch_opts(self, *args, **kwargs):
+        if self._mode is None:
             return self._base_opts(*args, **kwargs)
         elif self._mode == 'holomap':
             return self._holomap_opts(*args, **kwargs)

--- a/holoviews/core/options.py
+++ b/holoviews/core/options.py
@@ -44,7 +44,7 @@ import numpy as np
 import param
 from .tree import AttrTree
 from .util import sanitize_identifier, group_sanitizer,label_sanitizer, basestring, OrderedDict
-from .util import deprecated_opts_signature, disable_constant, config
+from .util import deprecated_opts_signature, disable_constant
 from .pprint import InfoPrinter, PrettyPrinter
 
 

--- a/holoviews/core/options.py
+++ b/holoviews/core/options.py
@@ -43,7 +43,7 @@ import numpy as np
 
 import param
 from .tree import AttrTree
-from .util import sanitize_identifier, group_sanitizer,label_sanitizer, basestring, OrderedDict
+from .util import sanitize_identifier, group_sanitizer,label_sanitizer, basestring, OrderedDict, config
 from .util import deprecated_opts_signature, disable_constant
 from .pprint import InfoPrinter, PrettyPrinter
 

--- a/holoviews/core/options.py
+++ b/holoviews/core/options.py
@@ -235,7 +235,8 @@ class Opts(object):
             from ..util import opts
             if options is not None:
                 kwargs['options'] = options
-            return opts.apply_groups(self._obj, **dict(kwargs, **new_kwargs))
+            # Should not have to do clone=False and output group missing
+            return opts.apply_groups(self._obj, **dict(kwargs, clone=False, **new_kwargs))
 
         kwargs['clone'] = False if clone is None else clone
         return self._obj.options(*args, **kwargs)
@@ -1471,6 +1472,7 @@ class Store(object):
             opt_groups = {'plot': Options(allowed_keywords=plot_opts)}
             if not isinstance(view_class, CompositeOverlay) or hasattr(plot, 'style_opts'):
                  opt_groups.update({'style': Options(allowed_keywords=style_opts),
+                                    'output':Options(allowed_keywords=['backend']),
                                     'norm':  Options(framewise=False, axiswise=False,
                                                      allowed_keywords=['framewise',
                                                                        'axiswise'])})

--- a/holoviews/core/options.py
+++ b/holoviews/core/options.py
@@ -588,7 +588,10 @@ class Options(param.Parameterized):
 
     _option_groups = ['style', 'plot', 'norm', 'output']
 
-    def __init__(self, key=None, allowed_keywords=[], merge_keywords=True, max_cycles=None, **kwargs):
+    _output_allowed_kws = ['backend']
+
+    def __init__(self, key=None, allowed_keywords=[], merge_keywords=True,
+                 max_cycles=None, **kwargs):
 
         invalid_kws = []
         for kwarg in sorted(kwargs.keys()):
@@ -1474,7 +1477,7 @@ class Store(object):
             style_opts = Keywords(style_opts, target=view_class.__name__)
 
             opt_groups = {'plot':   Options(allowed_keywords=plot_opts),
-                          'output': Options(allowed_keywords=['backend'])}
+                          'output': Options(allowed_keywords=Options._output_allowed_kws)}
             if not isinstance(view_class, CompositeOverlay) or hasattr(plot, 'style_opts'):
                  opt_groups.update({'style': Options(allowed_keywords=style_opts),
                                     'norm':  Options(framewise=False, axiswise=False,

--- a/holoviews/core/options.py
+++ b/holoviews/core/options.py
@@ -224,13 +224,6 @@ class Opts(object):
 
         # By default do not clone in .opts method
         clone = kwargs.get('clone', None)
-
-        if apply_groups and config.future_deprecations:
-            msg = ("Calling the .opts method with options broken down by options "
-                   "group (i.e. separate plot, style and norm groups) is deprecated. "
-                   "Use the .options method converting to the simplified format "
-                   "instead or use hv.opts.apply_groups for backward compatibility.")
-            param.main.warning(msg)
         if apply_groups:
             from ..util import opts
             if options is not None:

--- a/holoviews/core/pprint.py
+++ b/holoviews/core/pprint.py
@@ -374,7 +374,7 @@ class PrettyPrinter(param.Parameterized):
                                          defaults=cls_or_slf.show_defaults)
             if gopts:
                 options.update(gopts.kwargs)
-        opts = Options(**options)
+        opts = Options(**{k:v for k,v in options.items() if k != 'backend'})
         return opts
 
     @bothmethod

--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -242,7 +242,7 @@ def deprecated_opts_signature(args, kwargs):
     """
     from .options import Options
     groups = set(Options._option_groups)
-    opts = {kw for kw in kwargs if kw not in ('backend', 'clone')}
+    opts = {kw for kw in kwargs if kw !='clone'}
     apply_groups = False
     options = None
     new_kwargs = {}

--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -242,7 +242,7 @@ def deprecated_opts_signature(args, kwargs):
     """
     from .options import Options
     groups = set(Options._option_groups)
-    opts = {kw for kw in kwargs if kw !='clone'}
+    opts = {kw for kw in kwargs if kw != 'clone'}
     apply_groups = False
     options = None
     new_kwargs = {}

--- a/holoviews/tests/core/testdimensioned.py
+++ b/holoviews/tests/core/testdimensioned.py
@@ -38,7 +38,8 @@ class CustomBackendTestCase(LoggingComparisonTestCase):
         style_opts = Keywords(['style_opt1', 'style_opt2']+custom_style, name)
         plot_opts = Keywords(['plot_opt1', 'plot_opt2']+custom_plot, name)
         opt_groups = {'plot': Options(allowed_keywords=plot_opts),
-                      'style': Options(allowed_keywords=style_opts)}
+                      'style': Options(allowed_keywords=style_opts),
+                      'output':Options(allowed_keywords=['backend'])}
         Store._options[backend][name] = opt_groups
 
 

--- a/holoviews/tests/core/testdimensioned.py
+++ b/holoviews/tests/core/testdimensioned.py
@@ -39,7 +39,7 @@ class CustomBackendTestCase(LoggingComparisonTestCase):
         plot_opts = Keywords(['plot_opt1', 'plot_opt2']+custom_plot, name)
         opt_groups = {'plot': Options(allowed_keywords=plot_opts),
                       'style': Options(allowed_keywords=style_opts),
-                      'output':Options(allowed_keywords=['backend'])}
+                      'output': Options(allowed_keywords=['backend'])}
         Store._options[backend][name] = opt_groups
 
 

--- a/holoviews/tests/core/testoptions.py
+++ b/holoviews/tests/core/testoptions.py
@@ -1014,6 +1014,31 @@ class TestCrossBackendOptionSpecification(ComparisonTestCase):
         self.assertEqual(bokeh_lookup['cmap'], 'Purple')
         self.assert_output_options_group_empty(img)
 
+    def test_mpl_bokeh_mpl_via_builders_opts_method_literal_implicit_backend(self):
+        img = Image(np.random.rand(10,10))
+        curve = Curve([1,2,3])
+        overlay = img * curve
+        Store.set_current_backend('matplotlib')
+
+        literal = {'Curve':
+                   {'style':dict(color='orange'), 'output':dict(backend='matplotlib')},
+                   'Image':
+                   {'style':dict(cmap='jet'), 'output':dict(backend='bokeh')}
+                   }
+        styled = overlay.opts(literal)
+        mpl_curve_lookup = Store.lookup_options('matplotlib', styled.Curve.I, 'style')
+        self.assertEqual(mpl_curve_lookup.kwargs['color'], 'orange')
+
+        mpl_img_lookup = Store.lookup_options('matplotlib', styled.Image.I, 'style')
+        self.assertNotEqual(mpl_img_lookup.kwargs['cmap'], 'jet')
+
+        bokeh_curve_lookup = Store.lookup_options('bokeh', styled.Curve.I, 'style')
+        self.assertNotEqual(bokeh_curve_lookup.kwargs['color'], 'orange')
+
+        bokeh_img_lookup = Store.lookup_options('bokeh', styled.Image.I, 'style')
+        self.assertEqual(bokeh_img_lookup.kwargs['cmap'], 'jet')
+
+
 
     def test_mpl_bokeh_output_options_group_expandable(self):
         original_allowed_kws = Options._output_allowed_kws[:]

--- a/holoviews/tests/core/testoptions.py
+++ b/holoviews/tests/core/testoptions.py
@@ -1000,6 +1000,16 @@ class TestCrossBackendOptionSpecification(ComparisonTestCase):
         self.assertEqual(bokeh_lookup['cmap'], 'Purple')
         self.assert_output_options_group_empty(img)
 
+
+    def test_mpl_bokeh_mpl_via_dict_backend_keyword(self):
+        curve = Curve([1,2,3])
+        styled_mpl = curve.opts({'Curve': dict(color='red')}, backend='matplotlib')
+        styled = styled_mpl.opts({'Curve': dict(color='green')}, backend='bokeh')
+        mpl_lookup = Store.lookup_options('matplotlib', styled, 'style')
+        self.assertEqual(mpl_lookup.kwargs['color'], 'red')
+        bokeh_lookup = Store.lookup_options('bokeh', styled, 'style')
+        self.assertEqual(bokeh_lookup.kwargs['color'], 'green')
+
     def test_mpl_bokeh_mpl_via_builders_opts_method_implicit_backend(self):
         img = Image(np.random.rand(10,10))
         Store.set_current_backend('matplotlib')

--- a/holoviews/tests/core/testoptions.py
+++ b/holoviews/tests/core/testoptions.py
@@ -1065,6 +1065,28 @@ class TestCrossBackendOptionSpecification(ComparisonTestCase):
         self.assertEqual(bokeh_img_lookup.kwargs['cmap'], 'jet')
 
 
+    def test_mpl_bokeh_mpl_via_builders_opts_method_flat_literal_explicit_backend(self):
+        img = Image(np.random.rand(10,10))
+        curve = Curve([1,2,3])
+        overlay = img * curve
+        Store.set_current_backend('matplotlib')
+
+        literal = {'Curve': dict(color='orange', backend='matplotlib'),
+                   'Image': dict(cmap='jet', backend='bokeh')
+                   }
+        styled = overlay.opts(literal)
+        mpl_curve_lookup = Store.lookup_options('matplotlib', styled.Curve.I, 'style')
+        self.assertEqual(mpl_curve_lookup.kwargs['color'], 'orange')
+
+        mpl_img_lookup = Store.lookup_options('matplotlib', styled.Image.I, 'style')
+        self.assertNotEqual(mpl_img_lookup.kwargs['cmap'], 'jet')
+
+        bokeh_curve_lookup = Store.lookup_options('bokeh', styled.Curve.I, 'style')
+        self.assertNotEqual(bokeh_curve_lookup.kwargs['color'], 'orange')
+
+        bokeh_img_lookup = Store.lookup_options('bokeh', styled.Image.I, 'style')
+        self.assertEqual(bokeh_img_lookup.kwargs['cmap'], 'jet')
+
 
     def test_mpl_bokeh_output_options_group_expandable(self):
         original_allowed_kws = Options._output_allowed_kws[:]

--- a/holoviews/tests/core/testoptions.py
+++ b/holoviews/tests/core/testoptions.py
@@ -1014,7 +1014,33 @@ class TestCrossBackendOptionSpecification(ComparisonTestCase):
         self.assertEqual(bokeh_lookup['cmap'], 'Purple')
         self.assert_output_options_group_empty(img)
 
+
     def test_mpl_bokeh_mpl_via_builders_opts_method_literal_implicit_backend(self):
+        img = Image(np.random.rand(10,10))
+        curve = Curve([1,2,3])
+        overlay = img * curve
+        Store.set_current_backend('matplotlib')
+
+        literal = {'Curve':
+                   {'style':dict(color='orange')},
+                   'Image':
+                   {'style':dict(cmap='jet'), 'output':dict(backend='bokeh')}
+                   }
+        styled = overlay.opts(literal)
+        mpl_curve_lookup = Store.lookup_options('matplotlib', styled.Curve.I, 'style')
+        self.assertEqual(mpl_curve_lookup.kwargs['color'], 'orange')
+
+        mpl_img_lookup = Store.lookup_options('matplotlib', styled.Image.I, 'style')
+        self.assertNotEqual(mpl_img_lookup.kwargs['cmap'], 'jet')
+
+        bokeh_curve_lookup = Store.lookup_options('bokeh', styled.Curve.I, 'style')
+        self.assertNotEqual(bokeh_curve_lookup.kwargs['color'], 'orange')
+
+        bokeh_img_lookup = Store.lookup_options('bokeh', styled.Image.I, 'style')
+        self.assertEqual(bokeh_img_lookup.kwargs['cmap'], 'jet')
+
+
+    def test_mpl_bokeh_mpl_via_builders_opts_method_literal_explicit_backend(self):
         img = Image(np.random.rand(10,10))
         curve = Curve([1,2,3])
         overlay = img * curve

--- a/holoviews/tests/core/testoptions.py
+++ b/holoviews/tests/core/testoptions.py
@@ -937,6 +937,104 @@ class TestCrossBackendOptions(ComparisonTestCase):
         with self.assertRaisesRegexp(ValueError, err):
             opts.Curve(foobar=3)
 
+
+class TestCrossBackendOptionSpecification(ComparisonTestCase):
+    """
+    Test the style system can style a single object across backends.
+    """
+
+    def setUp(self):
+        if 'matplotlib' not in Store.renderers:
+            raise SkipTest("Cross background tests assumes matplotlib is available")
+        if 'bokeh' not in Store.renderers:
+            raise SkipTest("Cross background tests assumes bokeh is available.")
+
+        # Some tests require that plotly isn't loaded
+        self.plotly_options = Store._options.pop('plotly', None)
+        self.store_mpl = OptionTree(sorted(Store.options(backend='matplotlib').items()),
+                                    groups=Options._option_groups)
+        self.store_bokeh = OptionTree(sorted(Store.options(backend='bokeh').items()),
+                                    groups=Options._option_groups)
+        super(TestCrossBackendOptionSpecification, self).setUp()
+
+    def tearDown(self):
+        Store.options(val=self.store_mpl, backend='matplotlib')
+        Store.options(val=self.store_bokeh, backend='bokeh')
+        Store.current_backend = 'matplotlib'
+        Store._custom_options = {k:{} for k in Store._custom_options.keys()}
+
+        if self.plotly_options is not None:
+            Store._options['plotly'] = self.plotly_options
+
+        super(TestCrossBackendOptionSpecification, self).tearDown()
+
+    def assert_output_options_group_empty(self, obj):
+        mpl_output_lookup = Store.lookup_options('matplotlib', obj, 'output').options
+        self.assertEqual(mpl_output_lookup, {})
+        bokeh_output_lookup = Store.lookup_options('bokeh', obj, 'output').options
+        self.assertEqual(bokeh_output_lookup, {})
+
+    def test_mpl_bokeh_mpl_via_option_objects_opts_method(self):
+        img = Image(np.random.rand(10,10))
+        mpl_opts = Options('Image', cmap='Blues', backend='matplotlib')
+        bokeh_opts = Options('Image', cmap='Purple', backend='bokeh')
+        self.assertEqual(mpl_opts.kwargs['backend'], 'matplotlib')
+        self.assertEqual(bokeh_opts.kwargs['backend'], 'bokeh')
+        img.opts(mpl_opts, bokeh_opts)
+        mpl_lookup = Store.lookup_options('matplotlib', img, 'style').options
+        self.assertEqual(mpl_lookup['cmap'], 'Blues')
+        bokeh_lookup = Store.lookup_options('bokeh', img, 'style').options
+        self.assertEqual(bokeh_lookup['cmap'], 'Purple')
+        self.assert_output_options_group_empty(img)
+
+    def test_mpl_bokeh_mpl_via_builders_opts_method(self):
+        img = Image(np.random.rand(10,10))
+        mpl_opts = opts.Image(cmap='Blues', backend='matplotlib')
+        bokeh_opts = opts.Image(cmap='Purple', backend='bokeh')
+        self.assertEqual(mpl_opts.kwargs['backend'], 'matplotlib')
+        self.assertEqual(bokeh_opts.kwargs['backend'], 'bokeh')
+        img.opts(mpl_opts, bokeh_opts)
+        mpl_lookup = Store.lookup_options('matplotlib', img, 'style').options
+        self.assertEqual(mpl_lookup['cmap'], 'Blues')
+        bokeh_lookup = Store.lookup_options('bokeh', img, 'style').options
+        self.assertEqual(bokeh_lookup['cmap'], 'Purple')
+        self.assert_output_options_group_empty(img)
+
+    def test_mpl_bokeh_mpl_via_builders_opts_method_implicit_backend(self):
+        img = Image(np.random.rand(10,10))
+        Store.set_current_backend('matplotlib')
+        mpl_opts = opts.Image(cmap='Blues')
+        bokeh_opts = opts.Image(cmap='Purple', backend='bokeh')
+        self.assertEqual('backend' not in mpl_opts.kwargs, True)
+        self.assertEqual(bokeh_opts.kwargs['backend'], 'bokeh')
+        img.opts(mpl_opts, bokeh_opts)
+        mpl_lookup = Store.lookup_options('matplotlib', img, 'style').options
+        self.assertEqual(mpl_lookup['cmap'], 'Blues')
+        bokeh_lookup = Store.lookup_options('bokeh', img, 'style').options
+        self.assertEqual(bokeh_lookup['cmap'], 'Purple')
+        self.assert_output_options_group_empty(img)
+
+
+    def test_mpl_bokeh_output_options_group_expandable(self):
+        original_allowed_kws = Options._output_allowed_kws[:]
+        Options._output_allowed_kws = ['backend', 'file_format_example']
+        # Re-register
+        Store.register({Curve: plotting.mpl.CurvePlot}, 'matplotlib')
+        Store.register({Curve: plotting.bokeh.CurvePlot}, 'bokeh')
+
+        curve_bk = Options('Curve', backend='bokeh', color='blue')
+        curve_mpl = Options('Curve', backend='matplotlib', color='red',
+                            file_format_example='SVG')
+        c = Curve([1,2,3])
+        styled = c.opts(curve_bk, curve_mpl)
+        self.assertEqual(Store.lookup_options('matplotlib', styled, 'output').kwargs,
+                         {'backend':'matplotlib', 'file_format_example':'SVG'})
+
+        self.assertEqual(Store.lookup_options('bokeh', styled, 'output').kwargs,
+                         {})
+        Options._output_allowed_kws = original_allowed_kws
+
+
 class TestCrossBackendOptionPickling(TestCrossBackendOptions):
 
     cleanup = ['test_raw_pickle.pkl', 'test_pickle_mpl_bokeh.pkl']

--- a/holoviews/util/__init__.py
+++ b/holoviews/util/__init__.py
@@ -83,7 +83,9 @@ class opts(param.ParameterizedFunction):
        strict, invalid keywords prevent the options being applied.""")
 
     def __call__(self, *args, **params):
-        if params and not args:
+        if not params and not args:
+            return Options()
+        elif params and not args:
             return Options(**params)
 
         if len(args) == 1:

--- a/holoviews/util/__init__.py
+++ b/holoviews/util/__init__.py
@@ -159,6 +159,9 @@ class opts(param.ParameterizedFunction):
     @classmethod
     def _grouped_backends(cls, options, backend):
         "Group options by backend and filter out output group appropriately"
+
+        if options is None:
+            return [(backend or Store.current_backend, options)]
         dfltdict = defaultdict(dict)
         for spec, groups in options.items():
             if 'output' not in groups.keys() or len(groups['output'])==0:

--- a/holoviews/util/__init__.py
+++ b/holoviews/util/__init__.py
@@ -152,7 +152,7 @@ class opts(param.ParameterizedFunction):
                         spec['output']['backend'] = backend # Override
                 elif 'output' in spec:
                     # Set the kwarg from the output group
-                    backend = spec['output']['backend']
+                    backend = spec['output'].get('backend', None)
                     # Should not have to do this!
                     clone = False
 

--- a/holoviews/util/__init__.py
+++ b/holoviews/util/__init__.py
@@ -141,10 +141,10 @@ class opts(param.ParameterizedFunction):
         return options
 
     @classmethod
-    def _apply_groups_to_backend(cls, obj, options, backend, clone, kwargs):
+    def _apply_groups_to_backend(cls, obj, options, backend, clone):
         "Apply the groups to a single specified backend"
         obj_handle = obj
-        if options is None and kwargs == {}:
+        if options is None:
             if clone:
                 obj_handle = obj.map(lambda x: x.clone(id=None))
             else:
@@ -208,7 +208,7 @@ class opts(param.ParameterizedFunction):
 
 
         backend = backend or Store.current_backend
-        return cls._apply_groups_to_backend(obj, options, backend, clone, kwargs)
+        return cls._apply_groups_to_backend(obj, options, backend, clone)
 
     @classmethod
     def _process_magic(cls, options, strict, backends=None):

--- a/holoviews/util/__init__.py
+++ b/holoviews/util/__init__.py
@@ -192,10 +192,10 @@ class opts(param.ParameterizedFunction):
 
 
         backend = backend or Store.current_backend
-        return cls._apply_groups_to_backend(obj, options, backend, clone)
+        return cls._apply_groups_to_backend(obj, options, backend, clone, kwargs)
 
     @classmethod
-    def _apply_groups_to_backend(cls, obj, options, backend, clone):
+    def _apply_groups_to_backend(cls, obj, options, backend, clone, kwargs):
         "Apply the groups to a single specified backend"
         obj_handle = obj
         if options is None and kwargs == {}:

--- a/holoviews/util/__init__.py
+++ b/holoviews/util/__init__.py
@@ -148,10 +148,11 @@ class opts(param.ParameterizedFunction):
         if options is not None:
             for spec in options.values():
                 if backend is not None: # Backend kwarg overriding the spec
-                    spec['output']['backend'] = backend # Override
+                    if 'output' in spec:
+                        spec['output']['backend'] = backend # Override
                 elif 'output' in spec:
                     # Set the kwarg from the output group
-                    backend= spec['output']['backend']
+                    backend = spec['output']['backend']
                     # Should not have to do this!
                     clone = False
 

--- a/holoviews/util/__init__.py
+++ b/holoviews/util/__init__.py
@@ -307,7 +307,7 @@ class opts(param.ParameterizedFunction):
 
         if backend and not used_fallback:
             cls.param.warning("All supplied Options objects already define a backend, "
-                              "backend override backend=%r will be ignored." % backend)
+                              "backend override %r will be ignored." % backend)
 
         return [(bk, cls._expand_options(o, bk)) for (bk, o) in groups.items()]
 

--- a/holoviews/util/__init__.py
+++ b/holoviews/util/__init__.py
@@ -154,7 +154,7 @@ class opts(param.ParameterizedFunction):
                     # Set the kwarg from the output group
                     backend = spec['output'].get('backend', None)
                     # Should not have to do this!
-                    clone = False
+                    # clone = False
 
         backend = backend or Store.current_backend
         if isinstance(options, basestring):

--- a/holoviews/util/__init__.py
+++ b/holoviews/util/__init__.py
@@ -152,8 +152,7 @@ class opts(param.ParameterizedFunction):
         elif clone:
             obj_handle = obj.map(lambda x: x.clone(id=x.id))
 
-        StoreOptions.set_options(obj_handle, options, backend=backend)
-        return obj_handle
+        return StoreOptions.set_options(obj_handle, options, backend=backend)
 
 
     @classmethod

--- a/holoviews/util/__init__.py
+++ b/holoviews/util/__init__.py
@@ -123,7 +123,7 @@ class opts(param.ParameterizedFunction):
         a type[.group][.label] specification, e.g.:
 
             opts.apply_groups(obj, {'Image': {'plot':  {'show_title': False},
-                                                    'style': {'cmap': 'viridis}}})
+                                              'style': {'cmap': 'viridis}}})
 
         If no opts are supplied all options on the object will be reset.
 
@@ -285,8 +285,8 @@ class opts(param.ParameterizedFunction):
     def _expand_options(cls, options, backend=None):
         """
         Validates and expands a dictionaries of options indexed by
-        type[.group][.label] keys into separate style, plot and norm
-        options.
+        type[.group][.label] keys into separate style, plot, norm and
+        output options.
 
             opts._expand_options({'Image': dict(cmap='viridis', show_title=False)})
 

--- a/holoviews/util/__init__.py
+++ b/holoviews/util/__init__.py
@@ -179,7 +179,6 @@ class opts(param.ParameterizedFunction):
         Returns:
             Returns the object or a clone with the options applied
         """
-        backend = backend or Store.current_backend
         if isinstance(options, basestring):
             from ..util.parser import OptsSpec
             try:
@@ -191,6 +190,13 @@ class opts(param.ParameterizedFunction):
         if kwargs:
             options = cls._group_kwargs_to_options(obj, kwargs)
 
+
+        backend = backend or Store.current_backend
+        return cls._apply_groups_to_backend(obj, options, backend, clone)
+
+    @classmethod
+    def _apply_groups_to_backend(cls, obj, options, backend, clone):
+        "Apply the groups to a single specified backend"
         obj_handle = obj
         if options is None and kwargs == {}:
             if clone:

--- a/holoviews/util/__init__.py
+++ b/holoviews/util/__init__.py
@@ -164,12 +164,12 @@ class opts(param.ParameterizedFunction):
         dfltdict = defaultdict(dict)
         for spec, groups in options.items():
             if 'output' not in groups.keys() or len(groups['output'])==0:
-                dfltdict[backend or Store.current_backend][spec] = groups
+                dfltdict[backend or Store.current_backend][spec.strip()] = groups
             elif set(groups['output'].keys()) - set(['backend']):
-                dfltdict[groups['output']['backend']][spec] = groups
+                dfltdict[groups['output']['backend']][spec.strip()] = groups
             elif ['backend'] == list(groups['output'].keys()):
                 filtered = {k:v for k,v in groups.items() if k != 'output'}
-                dfltdict[groups['output']['backend']][spec] = filtered
+                dfltdict[groups['output']['backend']][spec.strip()] = filtered
             else:
                 raise Exception('The output options group must have the backend keyword')
 

--- a/holoviews/util/__init__.py
+++ b/holoviews/util/__init__.py
@@ -155,6 +155,13 @@ class opts(param.ParameterizedFunction):
         StoreOptions.set_options(obj_handle, options, backend=backend)
         return obj_handle
 
+
+    @classmethod
+    def _grouped_backends(cls, options, backend):
+        "Group options by backend and filter out output group appropriately"
+        backend = backend or Store.current_backend
+        return [(backend, options)]
+
     @classmethod
     def apply_groups(cls, obj, options=None, backend=None, clone=True, **kwargs):
         """Applies nested options definition grouped by type.
@@ -206,9 +213,9 @@ class opts(param.ParameterizedFunction):
         if kwargs:
             options = cls._group_kwargs_to_options(obj, kwargs)
 
-
-        backend = backend or Store.current_backend
-        return cls._apply_groups_to_backend(obj, options, backend, clone)
+        for backend, backend_opts in cls._grouped_backends(options, backend):
+            obj = cls._apply_groups_to_backend(obj, backend_opts, backend, clone)
+        return obj
 
     @classmethod
     def _process_magic(cls, options, strict, backends=None):

--- a/holoviews/util/__init__.py
+++ b/holoviews/util/__init__.py
@@ -116,8 +116,7 @@ class opts(param.ParameterizedFunction):
                             ','.join(repr(k) for k in kwargs.keys()))
 
         # Check whether the user is specifying targets (such as 'Image.Foo')
-        targets = [(len(grp)==1 and isinstance(list(grp.values())[0], dict))
-                   for grp in kwargs.values()]
+        targets = [all(k[0].isupper() for k in grp.keys()) for grp in kwargs.values()]
         if any(targets) and not all(targets):
             raise Exception("Cannot mix target specification keys such as 'Image' with non-target keywords.")
         elif not any(targets):

--- a/holoviews/util/__init__.py
+++ b/holoviews/util/__init__.py
@@ -105,8 +105,9 @@ class opts(param.ParameterizedFunction):
 
 
     @classmethod
-    def _group_kwargs_to_options(cls, obj, kwargs, groups, backend_options):
-        "Format option group kwargs into canonical options format" 
+    def _group_kwargs_to_options(cls, obj, kwargs):
+        "Format option group kwargs into canonical options format"
+        groups = Options._option_groups
         if set(kwargs.keys()) - set(groups):
             raise Exception("Keyword options %s must be one of  %s" % (groups,
                             ','.join(repr(g) for g in groups)))
@@ -115,8 +116,8 @@ class opts(param.ParameterizedFunction):
                             ','.join(repr(k) for k in kwargs.keys()))
 
         # Check whether the user is specifying targets (such as 'Image.Foo')
-        entries = backend_options.children
-        targets = [k.split('.')[0] in entries for grp in kwargs.values() for k in grp]
+        targets = [(len(grp)==1 and isinstance(list(grp.values())[0], dict))
+                   for grp in kwargs.values()]
         if any(targets) and not all(targets):
             raise Exception("Cannot mix target specification keys such as 'Image' with non-target keywords.")
         elif not any(targets):
@@ -188,11 +189,8 @@ class opts(param.ParameterizedFunction):
                 options = OptsSpec.parse(
                     '{clsname} {options}'.format(clsname=obj.__class__.__name__,
                                                  options=options))
-
-        backend_options = Store.options(backend=backend)
-        groups = set(backend_options.groups.keys())
-        if kwargs and set(kwargs) <= groups:
-            options = cls._group_kwargs_to_options(obj, kwargs, groups, backend_options)
+        if kwargs:
+            options = cls._group_kwargs_to_options(obj, kwargs)
 
         obj_handle = obj
         if options is None and kwargs == {}:

--- a/holoviews/util/__init__.py
+++ b/holoviews/util/__init__.py
@@ -144,6 +144,17 @@ class opts(param.ParameterizedFunction):
         Returns:
             Returns the object or a clone with the options applied
         """
+
+        if options is not None:
+            for spec in options.values():
+                if backend is not None: # Backend kwarg overriding the spec
+                    spec['output']['backend'] = backend # Override
+                elif 'output' in spec:
+                    # Set the kwarg from the output group
+                    backend= spec['output']['backend']
+                    # Should not have to do this!
+                    clone = False
+
         backend = backend or Store.current_backend
         if isinstance(options, basestring):
             from ..util.parser import OptsSpec

--- a/holoviews/util/__init__.py
+++ b/holoviews/util/__init__.py
@@ -139,6 +139,22 @@ class opts(param.ParameterizedFunction):
                     dfltdict[identifier][grp] = kws
             options = dict(dfltdict)
         return options
+
+    @classmethod
+    def _apply_groups_to_backend(cls, obj, options, backend, clone, kwargs):
+        "Apply the groups to a single specified backend"
+        obj_handle = obj
+        if options is None and kwargs == {}:
+            if clone:
+                obj_handle = obj.map(lambda x: x.clone(id=None))
+            else:
+                obj.map(lambda x: setattr(x, 'id', None))
+        elif clone:
+            obj_handle = obj.map(lambda x: x.clone(id=x.id))
+
+        StoreOptions.set_options(obj_handle, options, backend=backend)
+        return obj_handle
+
     @classmethod
     def apply_groups(cls, obj, options=None, backend=None, clone=True, **kwargs):
         """Applies nested options definition grouped by type.
@@ -193,21 +209,6 @@ class opts(param.ParameterizedFunction):
 
         backend = backend or Store.current_backend
         return cls._apply_groups_to_backend(obj, options, backend, clone, kwargs)
-
-    @classmethod
-    def _apply_groups_to_backend(cls, obj, options, backend, clone, kwargs):
-        "Apply the groups to a single specified backend"
-        obj_handle = obj
-        if options is None and kwargs == {}:
-            if clone:
-                obj_handle = obj.map(lambda x: x.clone(id=None))
-            else:
-                obj.map(lambda x: setattr(x, 'id', None))
-        elif clone:
-            obj_handle = obj.map(lambda x: x.clone(id=x.id))
-
-        StoreOptions.set_options(obj_handle, options, backend=backend)
-        return obj_handle
 
     @classmethod
     def _process_magic(cls, options, strict, backends=None):


### PR DESCRIPTION
This PR builds on #3492 in order to tackle the suggestion in #3463: tracking backend in options should be done consistently with everything else by introducing an 'output' options group.