### PR TITLE
Implement optimized TriMesh wireframe rendering

### DIFF
--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -726,7 +726,6 @@ class trimesh_rasterize(aggregate):
         precompute = self.p.precompute
         if interp == 'linear': interp = 'bilinear'
         wireframe = False
-        print(interp, agg)
         if (not (element.vdims or (isinstance(element, TriMesh) and element.nodes.vdims))) and ds_version <= '0.6.9':
             self.p.aggregator = ds.any() if isinstance(agg, ds.any) or agg == 'any' else ds.count()
             return aggregate._process(self, element, key)
@@ -751,7 +750,7 @@ class trimesh_rasterize(aggregate):
             else:
                 vdim = element.vdims[0]
             agg = self._get_aggregator(element)
-            
+
         if element._plot_id in self._precomputed:
             precomputed = self._precomputed[element._plot_id]
         elif wireframe:
@@ -831,7 +830,9 @@ class rasterize(AggregationOperation):
 
     interpolation = param.ObjectSelector(
         default='bilinear', objects=['linear', 'nearest', 'bilinear', None, False], doc="""
-        The interpolation method to apply during rasterization.""")
+        The interpolation method to apply during rasterization.
+        Defaults to linear interpolation and None and False are aliases
+        of each other.""")
 
     _transforms = [(Image, regrid),
                    (TriMesh, trimesh_rasterize),

--- a/holoviews/tests/operation/testdatashader.py
+++ b/holoviews/tests/operation/testdatashader.py
@@ -320,8 +320,8 @@ class DatashaderRasterizeTests(ComparisonTestCase):
         vertices = [(0., 0.), (0., 1.), (1., 0), (1, 1)]
         trimesh = TriMesh((simplices, vertices))
         img = rasterize(trimesh, width=3, height=3, dynamic=False)
-        image = Image(np.array([[2, 1, 2], [1, 2, 1], [2, 1, 2]]),
-                      bounds=(0, 0, 1, 1), vdims='Count')
+        image = Image(np.array([[True, True, True], [True, True, True], [True, True, True]]),
+                      bounds=(0, 0, 1, 1), vdims='Any')
         self.assertEqual(img, image)
 
     def test_rasterize_trimesh_no_vdims_zero_range(self):
@@ -330,7 +330,16 @@ class DatashaderRasterizeTests(ComparisonTestCase):
         trimesh = TriMesh((simplices, vertices))
         img = rasterize(trimesh, height=2, x_range=(0, 0), dynamic=False)
         image = Image(([], [0.25, 0.75], np.zeros((2, 0))),
-                      bounds=(0, 0, 0, 1), xdensity=1, vdims='Count')
+                      bounds=(0, 0, 0, 1), xdensity=1, vdims='Any')
+        self.assertEqual(img, image)
+
+    def test_rasterize_trimesh_with_vdims_as_wireframe(self):
+        simplices = [(0, 1, 2, 0.5), (3, 2, 1, 1.5)]
+        vertices = [(0., 0.), (0., 1.), (1., 0), (1, 1)]
+        trimesh = TriMesh((simplices, vertices), vdims=['z'])
+        img = rasterize(trimesh, width=3, height=3, aggregator='any', interpolation=None, dynamic=False)
+        image = Image(np.array([[True, True, True], [True, True, True], [True, True, True]]),
+                      bounds=(0, 0, 1, 1), vdims='Any')
         self.assertEqual(img, image)
 
     def test_rasterize_trimesh(self):


### PR DESCRIPTION
Uses optimized datashader segments rendering for TriMesh wireframes and adds support for generating a wireframe using ``interpolation=None`` and ``aggregator='any'/'count'``.

Here's the performance profiling for the initial render (which includes the time converting the trimesh to a wireframe of paths and segments):

![bokeh_plot](https://user-images.githubusercontent.com/1550771/52814903-2b866880-3095-11e9-86b5-21c017eb67cf.png)

- [x] Add tests