### PR TITLE
Always warn for deprecated call

### DIFF
--- a/holoviews/core/dimension.py
+++ b/holoviews/core/dimension.py
@@ -306,9 +306,8 @@ class Dimension(param.Parameterized):
 
 
     def __call__(self, spec=None, **overrides):
-        if util.config.future_deprecations:
-            self.param.warning('Dimension.__call__ method has been deprecated, '
-                               'use the clone method instead.')
+        self.param.warning('Dimension.__call__ method has been deprecated, '
+                           'use the clone method instead.')
         return self.clone(spec=spec, **overrides)
 
 

--- a/holoviews/core/dimension.py
+++ b/holoviews/core/dimension.py
@@ -306,8 +306,9 @@ class Dimension(param.Parameterized):
 
 
     def __call__(self, spec=None, **overrides):
-        self.param.warning('Dimension.__call__ method has been deprecated, '
-                           'use the clone method instead.')
+        if util.config.future_deprecations:
+            self.param.warning('Dimension.__call__ method has been deprecated, '
+                               'use the clone method instead.')
         return self.clone(spec=spec, **overrides)
 
 
@@ -1228,18 +1229,16 @@ class Dimensioned(LabelledData):
     def __unicode__(self):
         return unicode(PrettyPrinter.pprint(self))
 
-    def __call__(self, options=None, **kwargs):
-        if util.config.warn_options_call:
-            self.param.warning(
-                'Use of __call__ to set options will be deprecated '
-                'in future. Use the equivalent opts method or use '
-                'the recommended .options method instead.')
+    def __call__(self, options=None, **kwargs):	
+        self.param.warning(	
+            'Use of __call__ to set options will be deprecated '	
+            'in the next major release (1.14.0). Use the equivalent .opts '
+            'method instead.')	
 
-        if not kwargs and options is None:
+        if not kwargs and options is None:	
             return self.opts.clear()
 
         return self.opts(options, **kwargs)
-
 
     def options(self, *args, **kwargs):
         """Applies simplified option definition returning a new object.


### PR DESCRIPTION
Looks like the last release still had the warning behind the [`util.config.future_deprecations` flag](https://github.com/pyviz/holoviews/blob/v1.11.2/holoviews/core/dimension.py#L453). This PR makes sure the warning is always issued so we can finally remove ``__call__`` immediately after the next release.

