### PR TITLE
ENH Stickplots

### DIFF
--- a/holoviews/element/chart.py
+++ b/holoviews/element/chart.py
@@ -5,7 +5,7 @@ import param
 from ..core import util
 from ..core import Dimension, Dataset, Element2D
 from ..core.data import GridInterface
-from .geom import Points, VectorField # noqa: backward compatible import
+from .geom import Points, VectorField, Sticks # noqa: backward compatible import
 from .stats import BoxWhisker         # noqa: backward compatible import
 
 
@@ -69,7 +69,7 @@ class Scatter(Chart):
     location along the x-axis while the first value dimension
     represents the location of the point along the y-axis.
     """
-    
+
     group = param.String(default='Scatter', constant=True)
 
 

--- a/holoviews/element/geom.py
+++ b/holoviews/element/geom.py
@@ -38,13 +38,14 @@ class Points(Geometry):
 
 class Sticks(Geometry):
     """
-    A VectorField represents a set of vectors in 2D space with an
+    A Stickplot represents a set of vectors in 2D space with an
     associated angle, as well as an optional magnitude and any number
     of other value dimensions. The angles are assumed to be defined in
     radians and by default the magnitude is assumed to be normalized
     to be between 0 and 1.
 
-    In contrast to VectorField, x and y dimensions need not be commensurate.
+    In contrast to VectorField, x and y dimensions need not be commensurate,
+    i.e. datetime axes are permitted.
     """
 
     group = param.String(default='Stickplot', constant=True)

--- a/holoviews/element/geom.py
+++ b/holoviews/element/geom.py
@@ -36,6 +36,22 @@ class Points(Geometry):
 
     _auto_indexable_1d = True
 
+class Sticks(Geometry):
+    """
+    A VectorField represents a set of vectors in 2D space with an
+    associated angle, as well as an optional magnitude and any number
+    of other value dimensions. The angles are assumed to be defined in
+    radians and by default the magnitude is assumed to be normalized
+    to be between 0 and 1.
+
+    In contrast to VectorField, x and y dimensions need not be commensurate.
+    """
+
+    group = param.String(default='Stickplot', constant=True)
+
+    vdims = param.List(default=[Dimension('Angle', cyclic=True, range=(0,2*np.pi)),
+                                Dimension('Magnitude')], bounds=(1, None))
+
 
 class VectorField(Geometry):
     """

--- a/holoviews/plotting/bokeh/__init__.py
+++ b/holoviews/plotting/bokeh/__init__.py
@@ -12,7 +12,8 @@ from ...element import (Curve, Points, Scatter, Image, Raster, Path,
                         ErrorBars, Text, HLine, VLine, Spline, Spikes,
                         Table, ItemTable, Area, HSV, QuadMesh, VectorField,
                         Graph, Nodes, EdgePaths, Distribution, Bivariate,
-                        TriMesh, Violin, Chord, Div, HexTiles, Labels, Sankey)
+                        TriMesh, Violin, Chord, Div, HexTiles, Labels, Sankey,
+                        Sticks)
 from ...core.options import Options, Cycle, Palette
 from ...core.util import LooseVersion, VersionError
 
@@ -33,7 +34,7 @@ from .callbacks import Callback # noqa (API import)
 from .element import OverlayPlot, ElementPlot
 from .chart import (PointPlot, CurvePlot, SpreadPlot, ErrorPlot, HistogramPlot,
                     SideHistogramPlot, BarPlot, SpikesPlot, SideSpikesPlot,
-                    AreaPlot, VectorFieldPlot)
+                    AreaPlot, VectorFieldPlot, StickPlot)
 from .graphs import GraphPlot, NodePlot, TriMeshPlot, ChordPlot
 from .heatmap import HeatMapPlot, RadialHeatMapPlot
 from .hex_tiles import HexTilesPlot
@@ -70,6 +71,7 @@ associations = {Overlay: OverlayPlot,
                 Spikes: SpikesPlot,
                 Area: AreaPlot,
                 VectorField: VectorFieldPlot,
+                Sticks: StickPlot,
                 Histogram: HistogramPlot,
 
                 # Rasters

--- a/holoviews/plotting/bokeh/chart.py
+++ b/holoviews/plotting/bokeh/chart.py
@@ -152,6 +152,99 @@ class PointPlot(LegendPlot, ColorbarPlot):
         data = {k: np.concatenate(v) for k, v in data.items()}
         return data, elmapping, style
 
+class StickPlot(ColorbarPlot):
+
+    # magnitude = param.ClassSelector(class_=(basestring, dim), doc="""
+    #     Dimension or dimension value transform that declares the magnitude
+    #     of each vector. Magnitude is expected to be scaled between 0-1,
+    #     by default the magnitudes are rescaled relative to the minimum
+    #     distance between vectors, this can be disabled with the
+    #     rescale_lengths option.""")
+    #
+    # # pivot = param.ObjectSelector(default='mid', objects=['mid', 'tip', 'tail'],
+    # #                              doc="""
+    # #     The point around which the arrows should pivot valid options
+    # #     include 'mid', 'tip' and 'tail'.""")
+    #
+
+    rescale_lengths = param.Boolean(default=True, doc="""
+        Whether the lengths will be rescaled to take into account the
+        smallest non-zero distance between two vectors.""")
+
+    # Deprecated parameters
+
+    color_index = param.ClassSelector(default=None, class_=(basestring, int),
+                                      allow_None=True, doc="""
+        Deprecated in favor of dimension value transform on color option,
+        e.g. `color=dim('Magnitude')`.
+        """)
+
+    size_index = param.ClassSelector(default=None, class_=(basestring, int),
+                                     allow_None=True, doc="""
+        Deprecated in favor of the magnitude option, e.g.
+        `magnitude=dim('Magnitude')`.
+        """)
+
+    style_opts = line_properties + ['scale', 'cmap']
+
+    _nonvectorized_styles = ['scale', 'cmap']
+
+    _plot_methods = dict(single='ray')
+
+    def _glyph_properties(self, *args):
+        properties = super(StickPlot, self)._glyph_properties(*args)
+        properties.pop('scale', None)
+        return properties
+
+    def _get_lengths(self, element, style, x_is_datetime):
+        if x_is_datetime:
+            # This value seems to work well with bokeh such that
+            # ray lengths are of the order of data point distances
+            input_scale_default = 86400*10.
+        else:
+            input_scale_default = 1.
+        input_scale = style.pop('scale', input_scale_default)
+
+        magnitudes = element.dimension_values(3).copy()
+        if self.rescale_lengths:
+            base_dist = get_min_distance(element)
+            magnitudes = magnitudes * base_dist
+        return magnitudes/input_scale
+
+    def get_data(self, element, ranges, style):
+        # Get x, y, angle, magnitude and color data
+        rads = element.dimension_values(2)
+        if self.invert_axes:
+            xidx, yidx = (1, 0)
+            rads = np.pi/2 - rads
+        else:
+            xidx, yidx = (0, 1)
+
+        # Compute ray positions
+        xs = element.dimension_values(xidx)
+        ys = element.dimension_values(yidx)
+
+        # is abscissa datetime axis?
+        # for length of Ray, bokeh considers abscissa only
+        x_is_datetime = np.issubdtype(xs.dtype, np.datetime64)
+        lens = self._get_lengths(element, style, x_is_datetime)
+        self.param.warning(lens.__repr__())
+
+        cdim = element.get_dimension(self.color_index)
+        cdata, cmapping = self._get_color_data(element, ranges, style,
+                                               name='line_color')
+
+        color = None
+        if cdim:
+            color = cdata.get(cdim.name)
+
+        data = {'x': xs, 'y': ys, 'length': lens, 'angle': rads}
+        mapping = dict(x='x', y='y', length='length', angle='angle')
+        if cdim and color is not None:
+            data[cdim.name] = color
+            mapping.update(cmapping)
+
+        return (data, mapping, style)
 
 
 class VectorFieldPlot(ColorbarPlot):

--- a/holoviews/plotting/bokeh/chart.py
+++ b/holoviews/plotting/bokeh/chart.py
@@ -189,7 +189,7 @@ class StickPlot(ColorbarPlot):
             # when x is datetime and y is float, then holoviews scales distance
             # in nanoseconds, but bokeh works in milliseconds...
             # needs a more fundamental fix than this
-            input_scale /= 1e6
+            input_scale *= 1e6
 
         magnitudes = element.dimension_values(3).copy()
         if self.rescale_lengths:


### PR DESCRIPTION
Just a draft for what I know by the name of "Stickplots" (probably mostly because that's what a popular script for Matlab is called) -  see https://github.com/pyviz/holoviews/issues/3486#issue-408802672. This is only for the bokeh backend - `Ray` is the only Element I know that actually allows specifying an angle on the canvas itself. This is important when one wants to use datetime axes (see #2467), as one often does in these plots (of e.g. wind direction/speed as a function of time). I've previously made these plots in matplotlib (and Matlab), but then you have to work with the aspect ratio (tends to be a mess).

Syntax is like `VectorField`'s: `hv.Sticks((time, y, angles, magnitudes))`.

This is certainly not ready to be merged, but I wanted to hear your opinions before I write tests etc. I'm not married to any of the specifics (name of the Element, number of kdims, ...).

![stickplot](https://user-images.githubusercontent.com/38992106/53065666-b3f07900-349a-11e9-8ebb-9b7e0551fe6c.png)