### PR TITLE
Attempt to fix ffmpeg export

### DIFF
--- a/holoviews/tests/plotting/matplotlib/testrenderer.py
+++ b/holoviews/tests/plotting/matplotlib/testrenderer.py
@@ -75,10 +75,5 @@ class MPLRendererTest(ComparisonTestCase):
         self.assertIn("<img src='data:image/gif", data['text/html'])
 
     def test_render_mp4(self):
-        try:
-            data, metadata = self.renderer.components(self.map1, 'mp4')
-        except ValueError:
-            # ignore linux issues temporarily
-            # ValueError: I/O operation on closed file
-            return
+        data, metadata = self.renderer.components(self.map1, 'mp4')
         self.assertIn("<source src='data:video/mp4", data['text/html'])

--- a/holoviews/tests/plotting/matplotlib/testrenderer.py
+++ b/holoviews/tests/plotting/matplotlib/testrenderer.py
@@ -65,13 +65,7 @@ class MPLRendererTest(ComparisonTestCase):
         self.assertEqual((w, h), (288, 288))
 
     def test_render_gif(self):
-        try:
-            data, metadata = self.renderer.components(self.map1, 'gif')
-        except IndexError:
-            # ignore linux issues temporarily
-            #     self._frames[0].save(
-            # IndexError: list index out of range
-            return
+        data, metadata = self.renderer.components(self.map1, 'gif')
         self.assertIn("<img src='data:image/gif", data['text/html'])
 
     def test_render_mp4(self):

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ extras_require['recommended'] = extras_require['notebook'] + [
 extras_require['examples'] = extras_require['recommended'] + [
     'networkx', 'pillow', 'xarray>=0.10.4', 'plotly>=3.4',
     'datashader', 'selenium', 'phantomjs', 'ffmpeg', 'streamz>=0.5.0',
-    'cftime', 'netcdf4']
+    'cftime', 'netcdf4', 'bzip2']
 
 # Extra third-party libraries
 extras_require['extras'] = extras_require['examples']+[


### PR DESCRIPTION
Attempts fix suggested in https://github.com/matplotlib/matplotlib/issues/8760 which is to add bzip2 dependency.

- [x] Reenables unit test for ffmpeg export