### PR TITLE
Handle Graph node_color correctly

### DIFF
--- a/examples/reference/elements/bokeh/Graph.ipynb
+++ b/examples/reference/elements/bokeh/Graph.ipynb
@@ -148,7 +148,7 @@
     "nodes = hv.Nodes((x, y, node_indices, node_labels), vdims='Type')\n",
     "graph = hv.Graph(((source, target, edge_weights), nodes, paths), vdims='Weight')\n",
     "\n",
-    "graph.redim.range(**padding).opts(color_index='Type', edge_color_index='Weight',\n",
+    "graph.redim.range(**padding).opts(node_color='Type', edge_color='Weight',\n",
     "                                  cmap=['blue', 'red'], edge_cmap='viridis')"
    ]
   },

--- a/holoviews/plotting/bokeh/__init__.py
+++ b/holoviews/plotting/bokeh/__init__.py
@@ -204,23 +204,22 @@ options.Labels = Options('style', text_align='center', text_baseline='middle')
 
 # Graphs
 options.Graph = Options(
-    'style', node_size=15, node_fill_color=Cycle(),
-    node_line_color='black', node_nonselection_fill_color=Cycle(),
-    node_hover_line_color='black', node_hover_fill_color='limegreen',
-    node_nonselection_alpha=0.2, edge_nonselection_alpha=0.2,
-    node_nonselection_line_color='black', edge_line_color='black',
-    edge_line_width=2, edge_nonselection_line_color='black',
+    'style', node_size=15, node_color=Cycle(), node_line_color='black',
+    node_nonselection_fill_color=Cycle(), node_hover_line_color='black',
+    node_hover_fill_color='limegreen', node_nonselection_alpha=0.2,
+    edge_nonselection_alpha=0.2, node_nonselection_line_color='black',
+    edge_color='black', edge_line_width=2, edge_nonselection_line_color='black',
     edge_hover_line_color='limegreen'
 )
 options.TriMesh = Options(
-    'style', node_size=5, node_line_color='black',
-    node_fill_color='white', edge_line_color='black',
-    node_hover_fill_color='limegreen', edge_line_width=1,
-    edge_hover_line_color='limegreen', edge_nonselection_alpha=0.2,
-    edge_nonselection_line_color='black', node_nonselection_alpha=0.2,
+    'style', node_size=5, node_line_color='black', node_color='white',
+    edge_line_color='black', node_hover_fill_color='limegreen',
+    edge_line_width=1, edge_hover_line_color='limegreen',
+    edge_nonselection_alpha=0.2, edge_nonselection_line_color='black',
+    node_nonselection_alpha=0.2,
 )
 options.TriMesh = Options('plot', tools=[])
-options.Chord = Options('style', node_size=15, node_fill_color=Cycle(),
+options.Chord = Options('style', node_size=15, node_color=Cycle(),
                         node_line_color='black',
                         node_selection_fill_color='limegreen',
                         node_nonselection_fill_color=Cycle(),

--- a/holoviews/plotting/bokeh/graphs.py
+++ b/holoviews/plotting/bokeh/graphs.py
@@ -105,6 +105,8 @@ class GraphPlot(CompositeElementPlot, ColorbarPlot, LegendPlot):
             return
         elstyle = self.lookup_options(element, 'style')
         cycle = elstyle.kwargs.get('edge_color')
+        if not isinstance(cycle, Cycle):
+            cycle = None
 
         idx = element.get_dimension_index(cdim)
         field = dimension_sanitizer(cdim.name)
@@ -193,7 +195,7 @@ class GraphPlot(CompositeElementPlot, ColorbarPlot, LegendPlot):
         # Handle node colors
         fixed_color = style.pop('node_color', None)
         cycle = self.lookup_options(element, 'style').kwargs.get('node_color')
-        if isinstance(cycle, Cycle):
+        if isinstance(cycle, Cycle) and 'cmap' not in style:
             colors = cycle
         else:
             colors = None

--- a/holoviews/plotting/bokeh/graphs.py
+++ b/holoviews/plotting/bokeh/graphs.py
@@ -189,9 +189,11 @@ class GraphPlot(CompositeElementPlot, ColorbarPlot, LegendPlot):
             layout = {str(k): (y, x) if self.invert_axes else (x, y)
                       for k, (x, y) in zip(index, node_positions)}
         point_data = {'index': index}
+
+        # Handle node colors
+        fixed_color = style.pop('node_color', None)
         cycle = self.lookup_options(element, 'style').kwargs.get('node_color')
         if isinstance(cycle, Cycle):
-            style.pop('node_color', None)
             colors = cycle
         else:
             colors = None
@@ -199,6 +201,8 @@ class GraphPlot(CompositeElementPlot, ColorbarPlot, LegendPlot):
             element.nodes, ranges, style, name='node_fill_color',
             colors=colors, int_categories=True
         )
+        if fixed_color is not None and not cdata:
+            style['node_color'] = fixed_color
         point_data.update(cdata)
         point_mapping = cmapping
         if 'node_fill_color' in point_mapping:
@@ -206,6 +210,7 @@ class GraphPlot(CompositeElementPlot, ColorbarPlot, LegendPlot):
                      ['node_fill_color', 'node_nonselection_fill_color']}
             point_mapping['node_nonselection_fill_color'] = point_mapping['node_fill_color']
 
+        # Handle edge colors
         edge_mapping = {}
         nan_node = index.max()+1 if len(index) else 0
         start, end = (element.dimension_values(i) for i in range(2))
@@ -270,6 +275,7 @@ class GraphPlot(CompositeElementPlot, ColorbarPlot, LegendPlot):
         "Computes the args and kwargs for the GraphRenderer"
         sources = []
         properties, mappings = {}, {}
+
         for key in ('scatter_1', self.edge_glyph):
             gdata = data.pop(key, {})
             group_style = dict(style)


### PR DESCRIPTION
Various Graph elements defined a default ``node_fill_color`` which is overrides any explicit ``node_color`` a user might set. This PR defines the ``node_color`` by default which can be overridden by either a user-defined ``node_color`` or a ``node_fill_color``.

Fixes https://github.com/pyviz/holoviews/issues/3516