### PR TITLE
Update matplotlib test data

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -150,6 +150,7 @@ setup_args.update(dict(
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
         "Operating System :: OS Independent",
         "Intended Audience :: Science/Research",
         "Intended Audience :: Developers",


### PR DESCRIPTION
The matplotlib 3.0.3 release has changed the test data, this PR is primarily meant to update that test data but also lists Python 3.7 as supported in setup.py.