### PR TITLE
Unified setup.py and meta.yaml

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -12,23 +12,26 @@ build:
   number: 0
   script: python setup.py --quiet install --single-version-externally-managed --record record.txt
   entry_points:
-    - holoviews = holoviews.util.command:main
+    {% for group,epoints in sdata.get("entry_points",{}).items() %}
+    {% for entry_point in epoints %}
+    - {{ entry_point }}
+    {% endfor %}
+    {% endfor %}
 
 requirements:
   build:
-    - python
-    - param >=1.6.1,<2.0
-    - numpy
-    - setuptools
+    - python {{ sdata['python_requires'] }}
+    {% for dep in sdata['extras_require']['build'] %}
+    - {{ dep }}
+    {% endfor %}
   run:
-    - python
-    - param >=1.8.0,<2.0
-    - pyviz_comms >=0.7.0
-    - numpy
-    - matplotlib>=2.1
-    - bokeh >=1.0.0,<1.1.0
-    - notebook
-    - ipython >=5.4.0,<=7.1.1  # <=7.1.1 due to tab completion regression
+    - python {{ sdata['python_requires'] }}
+    {% for dep in sdata.get('install_requires',{}) %}
+    - {{ dep }}
+    {% endfor %}
+    {% for dep in sdata['extras_require']['recommended'] %}
+    - {{ dep }}
+    {% endfor %}
 
 test:
   requires:

--- a/setup.py
+++ b/setup.py
@@ -19,13 +19,13 @@ extras_require['notebook'] = ['ipython>=5.4.0,<=7.1.1', 'notebook']
 
 # IPython Notebook + pandas + matplotlib + bokeh
 extras_require['recommended'] = extras_require['notebook'] + [
-    'pandas', 'matplotlib>=2.1', 'bokeh>=1.0.0', 'scipy', 'panel']
+    'pandas', 'matplotlib>=2.1', 'bokeh>=1.0.0,<1.1.0', 'panel']
 
 # Requirements to run all examples
 extras_require['examples'] = extras_require['recommended'] + [
     'networkx', 'pillow', 'xarray>=0.10.4', 'plotly>=3.4',
     'datashader', 'selenium', 'phantomjs', 'ffmpeg', 'streamz>=0.5.0',
-    'cftime', 'netcdf4', 'bzip2']
+    'cftime', 'netcdf4', 'bzip2', 'dask<1.1.3', 'scipy']
 
 # Extra third-party libraries
 extras_require['extras'] = extras_require['examples']+[


### PR DESCRIPTION
Temporarily pins dask to avoid regression in 1.1.3, which we will investigate separately.