### PR TITLE
add radius for node options for bokeh

### DIFF
--- a/holoviews/plotting/bokeh/graphs.py
+++ b/holoviews/plotting/bokeh/graphs.py
@@ -56,7 +56,7 @@ class GraphPlot(CompositeElementPlot, ColorbarPlot, LegendPlot):
 
     style_opts = (['edge_'+p for p in fill_properties+line_properties] +
                   ['node_'+p for p in fill_properties+line_properties] +
-                  ['node_size', 'cmap', 'edge_cmap', 'node_cmap'])
+                  ['node_size', 'cmap', 'edge_cmap', 'node_cmap', 'node_radius'])
 
     _nonvectorized_styles =  ['cmap', 'edge_cmap', 'node_cmap']
 


### PR DESCRIPTION
Zooming in causes the node sizes to re-scale, thus defeating the purpose of the zoom. To allow node size to *increase* with zoom-in, Bokeh 
needs the `radius` of the `Circle` set. 
This is discussed here: https://stackoverflow.com/questions/41168347/python-bokeh-google-maps-dynamic-glyph-size-based-on-zoom