### PR TITLE
Safe import to avoid tornado issue with nbconvert

### DIFF
--- a/holoviews/ipython/__init__.py
+++ b/holoviews/ipython/__init__.py
@@ -120,8 +120,13 @@ class notebook_extension(extension):
                 import nbformat # noqa (ensures availability)
             else:
                 from IPython import nbformat # noqa (ensures availability)
-            from .archive import notebook_archive
-            holoviews.archive = notebook_archive
+            try:
+                from .archive import notebook_archive
+                holoviews.archive = notebook_archive
+            except AttributeError as e:
+                if str(e) != "module 'tornado.web' has no attribute 'asynchronous'":
+                    raise
+
         except ImportError:
             pass
 


### PR DESCRIPTION
Right now you can't load the holoviews extension with latest tornado due to this issue https://github.com/jupyter/nbconvert/issues/894. This PR uses a safer import till the new nbconvert version comes out with a fix.