### PR TITLE
fixed user guide link

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -117,8 +117,9 @@ Once you have installed JupyterLab and the extension launch it with::
 
   jupyter-lab
 
-For more details on installing and configuring HoloViews see `the user
-guide <user_guide/index.html>`_.
+For more details on installing and configuring HoloViews see `the installing and configuring guide <user_guide/Installing_and_Configuring.html>`_. 
+
+After you have successfully installed and configured HoloViews, please see `Getting Started <getting_started/index.html>`_. 
 
 
 .. |PyPI| image:: https://img.shields.io/pypi/v/holoviews.svg

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -118,7 +118,7 @@ Once you have installed JupyterLab and the extension launch it with::
   jupyter-lab
 
 For more details on installing and configuring HoloViews see `the user
-guide <user_guide/Installing_and_Configuring.html>`_.
+guide <user_guide/index.html>`_.
 
 
 .. |PyPI| image:: https://img.shields.io/pypi/v/holoviews.svg

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -117,9 +117,9 @@ Once you have installed JupyterLab and the extension launch it with::
 
   jupyter-lab
 
-For more details on installing and configuring HoloViews see `the installing and configuring guide <user_guide/Installing_and_Configuring.html>`_. 
+For more details on installing and configuring HoloViews see `the installing and configuring guide <user_guide/Installing_and_Configuring>`_. 
 
-After you have successfully installed and configured HoloViews, please see `Getting Started <getting_started/index.html>`_. 
+After you have successfully installed and configured HoloViews, please see `Getting Started <getting_started/index>`_. 
 
 
 .. |PyPI| image:: https://img.shields.io/pypi/v/holoviews.svg


### PR DESCRIPTION
I was confused that the user guide link did not direct to the actual user guide page. It was actually intended to link the installing and configuring guide. Thus, I changed the wording from 'user guide' to 'installing and configuring guide'. In addition, I added a sentence directing people to the 'Getting started' link. I would like to go to the 'Getting started' page from the home page. 

