### PR TITLE
Fixes when specifying both data_aspect and responsive modes

### DIFF
--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -800,14 +800,14 @@ class ElementPlot(BokehPlot, GenericElementPlot):
                     plot.frame_height = int(width/aspect)
                     plot.plot_width, plot.plot_height = None, None
                 else:
-                    plot.aspect_ratio = aspect
+                    plot.aspect_ratio = 1./aspect
 
-                box_zoom = plot.select(type=tools.BoxZoomTool)
-                scroll_zoom = plot.select(type=tools.WheelZoomTool)
-                if box_zoom:
-                    box_zoom.match_aspect = True
-                if scroll_zoom:
-                    scroll_zoom.zoom_on_axis = False
+            box_zoom = plot.select(type=tools.BoxZoomTool)
+            scroll_zoom = plot.select(type=tools.WheelZoomTool)
+            if box_zoom:
+                box_zoom.match_aspect = True
+            if scroll_zoom:
+                scroll_zoom.zoom_on_axis = False
 
         if not self.drawn or xupdate:
             self._update_range(x_range, l, r, xfactors, self.invert_xaxis,

--- a/holoviews/plotting/bokeh/util.py
+++ b/holoviews/plotting/bokeh/util.py
@@ -301,8 +301,11 @@ def compute_layout_properties(
             height = None
         if fixed_height or not fixed_width:
             width = None
-        aspect_scale = 1 if aspect == 'equal' else data_aspect
-        if responsive:
+
+        aspect_scale = data_aspect
+        if aspect == 'equal':
+            aspect_scale = 1
+        elif responsive:
             aspect_ratio = aspect
     elif isnumeric(aspect):
         if responsive:

--- a/holoviews/plotting/bokeh/util.py
+++ b/holoviews/plotting/bokeh/util.py
@@ -302,6 +302,8 @@ def compute_layout_properties(
         if fixed_height or not fixed_width:
             width = None
         aspect_scale = 1 if aspect == 'equal' else data_aspect
+        if responsive:
+            aspect_ratio = aspect
     elif isnumeric(aspect):
         if responsive:
             aspect_ratio = aspect

--- a/holoviews/tests/plotting/bokeh/testelementplot.py
+++ b/holoviews/tests/plotting/bokeh/testelementplot.py
@@ -617,11 +617,24 @@ class TestElementPlot(LoggingComparisonTestCase, TestBokehPlot):
         self.log_handler.assertContains('WARNING', "responsive mode could not be enabled")
 
     def test_element_data_aspect_responsive(self):
-        curve = Curve([0, 0.5, 1, 1.5]).opts(data_aspect=2, responsive=True)
+        curve = Curve([0, 2]).opts(data_aspect=1, responsive=True)
         plot = bokeh_renderer.get_plot(curve)
-        self.assertEqual(plot.state.aspect_ratio, 1)
-        self.assertEqual(plot.state.aspect_scale, 2)
+        self.assertEqual(plot.state.aspect_ratio, 0.5)
+        self.assertEqual(plot.state.aspect_scale, 1)
         self.assertEqual(plot.state.sizing_mode, 'scale_both')
+
+    def test_element_data_aspect_and_aspect_responsive(self):
+        curve = Curve([0, 2]).opts(data_aspect=1, aspect=2, responsive=True)
+        plot = bokeh_renderer.get_plot(curve)
+        self.assertEqual(plot.state.aspect_ratio, 2)
+        self.assertEqual(plot.state.aspect_scale, 1)
+        self.assertEqual(plot.state.sizing_mode, 'scale_both')
+        x_range = plot.handles['x_range']
+        y_range = plot.handles['y_range']
+        self.assertEqual(x_range.start, -1.5)
+        self.assertEqual(x_range.end, 2.5)
+        self.assertEqual(y_range.start, 0)
+        self.assertEqual(y_range.end, 2)
 
     def test_element_data_aspect_width_responsive(self):
         curve = Curve([0, 0.5, 1, 1.5]).opts(data_aspect=2, width=400, responsive=True)


### PR DESCRIPTION
Fixes a number of bugs in handling of aspect and responsive modes:

* Ensures that if data_aspect zoom tools are always locked
* Fixes inverted aspect_ratio when responsive=True
* Ensure that aspect is applied even if data_aspect is set