### PR TITLE
Improved support for style mapping constant values

### DIFF
--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -954,7 +954,8 @@ class ElementPlot(BokehPlot, GenericElementPlot):
                 continue
 
             if v.dimension in self.overlay_dims:
-                ds = Dataset([self.overlay_dims[v.dimension]], v.dimension)
+                ds = Dataset({d.name: v for d, v in self.overlay_dims.items()},
+                             list(self.overlay_dims))
                 val = v.apply(ds, ranges=ranges, flat=True)[0]
             elif isinstance(element, Path) and not isinstance(element, Contours):
                 val = np.concatenate([v.apply(el, ranges=ranges, flat=True)[:-1]

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -23,7 +23,7 @@ from bokeh.models.tickers import (
 from bokeh.models.widgets import Panel, Tabs
 from bokeh.plotting.helpers import _known_tools as known_tools
 
-from ...core import DynamicMap, CompositeOverlay, Element, Dimension
+from ...core import DynamicMap, CompositeOverlay, Element, Dimension, Dataset
 from ...core.options import abbreviated_exception, SkipRendering
 from ...core import util
 from ...element import Graph, VectorField, Path, Contours, Tiles
@@ -953,8 +953,9 @@ class ElementPlot(BokehPlot, GenericElementPlot):
                     'as not all dimensions could be resolved.' % (k, v))
                 continue
 
-            if len(v.ops) == 0 and v.dimension in self.overlay_dims:
-                val = self.overlay_dims[v.dimension]
+            if v.dimension in self.overlay_dims:
+                ds = Dataset([self.overlay_dims[v.dimension]], v.dimension)
+                val = v.apply(ds, ranges=ranges, flat=True)[0]
             elif isinstance(element, Path) and not isinstance(element, Contours):
                 val = np.concatenate([v.apply(el, ranges=ranges, flat=True)[:-1]
                                       for el in element.split()])
@@ -962,7 +963,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
                 val = v.apply(element, ranges=ranges, flat=True)
 
             if (not util.isscalar(val) and len(util.unique_array(val)) == 1 and
-                (not 'color' in k or validate('color', val))):
+                ((not 'color' in k or validate('color', val)) or k in self._nonvectorized_styles)):
                 val = val[0]
 
             if not util.isscalar(val):

--- a/holoviews/plotting/mpl/element.py
+++ b/holoviews/plotting/mpl/element.py
@@ -559,7 +559,8 @@ class ElementPlot(GenericElementPlot, MPLPlot):
                 continue
 
             if v.dimension in self.overlay_dims:
-                ds = Dataset([self.overlay_dims[v.dimension]], v.dimension)
+                ds = Dataset({d.name: v for d, v in self.overlay_dims.items()},
+                             list(self.overlay_dims))
                 val = v.apply(ds, ranges=ranges, flat=True)[0]
             elif type(element) is Path:
                 val = np.concatenate([v.apply(el, ranges=ranges, flat=True)[:-1]

--- a/holoviews/plotting/mpl/element.py
+++ b/holoviews/plotting/mpl/element.py
@@ -558,8 +558,9 @@ class ElementPlot(GenericElementPlot, MPLPlot):
                     % (k, v))
                 continue
 
-            if len(v.ops) == 0 and v.dimension in self.overlay_dims:
-                val = self.overlay_dims[v.dimension]
+            if v.dimension in self.overlay_dims:
+                ds = Dataset([self.overlay_dims[v.dimension]], v.dimension)
+                val = v.apply(ds, ranges=ranges, flat=True)[0]
             elif type(element) is Path:
                 val = np.concatenate([v.apply(el, ranges=ranges, flat=True)[:-1]
                                       for el in element.split()])

--- a/holoviews/tests/plotting/bokeh/testcurveplot.py
+++ b/holoviews/tests/plotting/bokeh/testcurveplot.py
@@ -398,7 +398,6 @@ class TestCurvePlot(TestBokehPlot):
                 self.assertEqual(color, 'red')
             else:
                 self.assertEqual(color, 'blue')
-            print(glyph.properties_with_values())
             linestyle = glyph.line_dash
             if cat == 'A':
                 self.assertEqual(linestyle, [])

--- a/holoviews/tests/plotting/bokeh/testcurveplot.py
+++ b/holoviews/tests/plotting/bokeh/testcurveplot.py
@@ -426,7 +426,6 @@ class TestCurvePlot(TestBokehPlot):
             else:
                 self.assertEqual(color, 'blue')
             linestyle = glyph.line_dash
-            print(linestyle)
             if ndoverlay[k].iloc[0, 3] == 'A':
                 self.assertEqual(linestyle, [])
             else:


### PR DESCRIPTION
Add support for style mapping constant values on an NdOverlay or in the dimensions of an element. This finally allows using style mapping to assign styles by NdOverlay value (addressing https://github.com/pyviz/holoviews/issues/3534) or by value dimension values, an example of that is the following:

```python
df = pd.DataFrame({
    'Time': np.tile(np.arange(100), 9),
    'y': np.random.randn(900).cumsum(axis=0),
    'gridsize': np.repeat([0, 1, 2, 0, 1, 2, 0, 1, 2], 100),
    'turbulence': np.repeat([0, 0, 0, 1, 1, 1, 2, 2, 2], 100)})

df['label'] = ['Gridsize: %s, Turbulence: %s' % (r.gridsize, r.turbulence) for i, r in df.iterrows()]

curves = hv.Dataset(df, ['Time']).to(hv.Curve, 'Time', ['y', 'gridsize','turbulence'], 'label')
curves.overlay('label').opts(
    opts.Curve(color=dim('gridsize').categorize({0: 'red', 1: 'blue', 2: 'green'}),
               line_dash=dim('turbulence').categorize({0: 'solid', 1: 'dashed', 2: 'dotdash'})),
    opts.NdOverlay(width=900, legend_position='right'))
```

![Screen Shot 2019-03-25 at 7 00 20 PM](https://user-images.githubusercontent.com/1550771/54946572-42d83180-4f30-11e9-8a2f-f3109d4d1c7a.png)

Here we mapped the gridsize dimension to color and the turbulence dimension to the line_dash style.

- [x] Add tests
- [x] Add matplotlib support