### PR TITLE
Ensure Dimension clone copies all parameters

### DIFF
--- a/holoviews/core/dimension.py
+++ b/holoviews/core/dimension.py
@@ -325,7 +325,7 @@ class Dimension(param.Parameterized):
         Returns:
             Cloned Dimension object
         """
-        settings = dict(self.get_param_values(onlychanged=True), **overrides)
+        settings = dict(self.get_param_values(), **overrides)
 
         if spec is None:
             spec = (self.name, overrides.get('label', self.label))
@@ -337,7 +337,6 @@ class Dimension(param.Parameterized):
                     'Using label as supplied by keyword ({!r}), ignoring '
                     'tuple value {!r}'.format(overrides['label'], spec[1]))
             spec = (spec[0],  overrides['label'])
-
         return self.__class__(spec, **{k:v for k,v in settings.items()
                                        if k not in ['name', 'label']})
 


### PR DESCRIPTION
The ``onlychanged=True`` check in param doesn't appear to be working at least in some cases. So using ``redim`` in certain cases drops Dimension parameters on clone. It's also not clear to me why ``onlychanged`` was there in the first place, there shouldn't be any harm in passing all of them along.

Fixes #3561 
