### PR TITLE
Unpin IPython and disable jedi completion by default

### DIFF
--- a/holoviews/ipython/__init__.py
+++ b/holoviews/ipython/__init__.py
@@ -100,6 +100,11 @@ class notebook_extension(extension):
         using the matplotlib backend) may be used. This may be useful to
         export figures to other formats such as PDF with nbconvert. """)
 
+    allow_jedi_completion = param.Boolean(default=False, doc="""
+       Whether to allow jedi tab-completion to be enabled in IPython.
+       Disabled by default because many HoloViews features rely on
+       tab-completion machinery not supported when using jedi.""")
+
     case_sensitive_completion = param.Boolean(default=False, doc="""
        Whether to monkey patch IPython to use the correct tab-completion
        behavior. """)
@@ -139,6 +144,8 @@ class notebook_extension(extension):
         if p.case_sensitive_completion:
             from IPython.core import completer
             completer.completions_sorting_key = self.completions_sorting_key
+        if not p.allow_jedi_completion:
+            ip.run_line_magic('config', 'IPCompleter.use_jedi = False')
 
         resources = self._get_resources(args, params)
 

--- a/setup.py
+++ b/setup.py
@@ -15,11 +15,11 @@ install_requires = ['param>=1.8.0,<2.0', 'numpy>=1.0', 'pyviz_comms>=0.7.2']
 extras_require = {}
 
 # Notebook dependencies
-extras_require['notebook'] = ['ipython>=5.4.0,<=7.1.1', 'notebook']
+extras_require['notebook'] = ['ipython>=5.4.0', 'notebook']
 
 # IPython Notebook + pandas + matplotlib + bokeh
 extras_require['recommended'] = extras_require['notebook'] + [
-    'pandas', 'matplotlib>=2.1', 'bokeh>=1.1.0dev10', 'panel']
+    'pandas', 'matplotlib>=2.1', 'bokeh>=1.1.0dev11', 'panel']
 
 # Requirements to run all examples
 extras_require['examples'] = extras_require['recommended'] + [


### PR DESCRIPTION
Not supporting newer versions of IPython is really not feasible in the long run, so I've made the holoviews extension disable jedi tab-completion in IPython, if someone really wants jedi completion they can toggle it with ``hv.extension(allow_jedi_completion=True)``.

Fixes https://github.com/pyviz/holoviews/issues/3540

@jlstevens @jbednar Thoughts on this appreciated, users were getting offered old versions of holoviews by conda because conda prefers to install an old version of a new package rather than downgrade the version of an existing package.
