### PR TITLE
Colorscale/colorbar fixes for Plotly backend

### DIFF
--- a/holoviews/plotting/plotly/chart3d.py
+++ b/holoviews/plotting/plotly/chart3d.py
@@ -46,7 +46,6 @@ class SurfacePlot(Chart3DPlot, ColorbarPlot):
     def graph_options(self, element, ranges, style):
         opts = super(SurfacePlot, self).graph_options(element, ranges, style)
         copts = self.get_color_opts(element.vdims[0], element, ranges, style)
-        copts['colorscale'] = style.get('cmap', 'Viridis')
         return dict(opts, **copts)
 
     def get_data(self, element, ranges, style):

--- a/holoviews/plotting/plotly/element.py
+++ b/holoviews/plotting/plotly/element.py
@@ -389,6 +389,7 @@ class ColorbarPlot(ElementPlot):
             else:
                 title = eldim.pprint_label
             opts['colorbar'] = dict(title=title, **self.colorbar_opts)
+            opts['showscale'] = True
         else:
             opts['showscale'] = False
 

--- a/holoviews/plotting/plotly/element.py
+++ b/holoviews/plotting/plotly/element.py
@@ -134,9 +134,9 @@ class ElementPlot(PlotlyPlot, GenericElementPlot):
         opts = self.graph_options(element, ranges, style)
         graphs = []
         for i, d in enumerate(data):
-            # Initialize graph
-            graph = self.init_graph(d, opts, index=i)
-            graphs.append(graph)
+            # Initialize traces
+            traces = self.init_graph(d, opts, index=i)
+            graphs.extend(traces)
         self.handles['graphs'] = graphs
 
         # Initialize layout
@@ -186,7 +186,7 @@ class ElementPlot(PlotlyPlot, GenericElementPlot):
             trace[self._style_key] = dict(trace[self._style_key])
             for s, val in vectorized.items():
                 trace[self._style_key][s] = val[index]
-        return trace
+        return [trace]
 
 
     def get_data(self, element, ranges, style):

--- a/holoviews/plotting/plotly/element.py
+++ b/holoviews/plotting/plotly/element.py
@@ -412,6 +412,21 @@ class ColorbarPlot(ElementPlot):
 
         cmap = style.pop('cmap', 'viridis')
         colorscale = get_colorscale(cmap, self.color_levels, cmin, cmax)
+
+        # Reduce colorscale length to <= 255 to work around
+        # https://github.com/plotly/plotly.js/issues/3699. Plotly.js performs
+        # colorscale interpolation internally so reducing the number of colors
+        # here makes very little difference to the displayed colorscale.
+        #
+        # Note that we need to be careful to make sure the first and last
+        # colorscale pairs, colorscale[0] and colorscale[-1], are preserved
+        # as the first and last in the subsampled colorscale
+        if isinstance(colorscale, list) and len(colorscale) > 255:
+            last_clr_pair = colorscale[-1]
+            step = int(np.ceil(len(colorscale) / 255))
+            colorscale = colorscale[0::step]
+            colorscale[-1] = last_clr_pair
+
         if cmin is not None:
             opts['cmin'] = cmin
         if cmax is not None:

--- a/holoviews/plotting/plotly/stats.py
+++ b/holoviews/plotting/plotly/stats.py
@@ -9,7 +9,7 @@ from .element import ElementPlot, ColorbarPlot
 class BivariatePlot(ChartPlot, ColorbarPlot):
 
     filled = param.Boolean(default=False)
-    
+
     ncontours = param.Integer(default=None)
 
     trace_kwargs = {'type': 'histogram2dcontour'}
@@ -20,10 +20,30 @@ class BivariatePlot(ChartPlot, ColorbarPlot):
 
     def graph_options(self, element, ranges, style):
         opts = super(BivariatePlot, self).graph_options(element, ranges, style)
+        copts = self.get_color_opts(element.vdims[0], element, ranges, style)
+
         if self.ncontours:
             opts['autocontour'] = False
             opts['ncontours'] = self.ncontours
-        opts['contours'] = {'coloring': 'fill' if self.filled else 'lines'}
+
+        # Make line width a little wider (default is less than 1)
+        opts['line'] = {'width': 1}
+
+        # Configure contours
+        opts['contours'] = {
+            'coloring': 'fill' if self.filled else 'lines',
+            'showlines': style.get('showlines', True)
+        }
+
+        # Add colorscale
+        opts['colorscale'] = copts['colorscale']
+
+        # Add colorbar
+        if 'colorbar' in copts:
+            opts['colorbar'] = copts['colorbar']
+
+        opts['showscale'] = copts.get('showscale', False)
+
         return opts
 
 
@@ -37,7 +57,7 @@ class DistributionPlot(ElementPlot):
 
     filled = param.Boolean(default=True, doc="""
         Whether the bivariate contours should be filled.""")
-    
+
     style_opts = ['color', 'dash', 'line_width']
 
     trace_kwargs = {'type': 'scatter', 'mode': 'lines'}
@@ -95,7 +115,7 @@ class BoxWhiskerPlot(MultiDistributionPlot):
     style_opts = ['color', 'alpha', 'outliercolor', 'marker', 'size']
 
     trace_kwargs = {'type': 'box'}
-    
+
     _style_key = 'marker'
 
     def graph_options(self, element, ranges, style):
@@ -107,7 +127,7 @@ class BoxWhiskerPlot(MultiDistributionPlot):
 
 class ViolinPlot(MultiDistributionPlot):
 
-    
+
     box = param.Boolean(default=True, doc="""
         Whether to draw a boxplot inside the violin""")
 
@@ -119,7 +139,7 @@ class ViolinPlot(MultiDistributionPlot):
     style_opts = ['color', 'alpha', 'outliercolor', 'marker', 'size']
 
     trace_kwargs = {'type': 'violin'}
-    
+
     _style_key = 'marker'
 
     def graph_options(self, element, ranges, style):

--- a/holoviews/plotting/plotly/util.py
+++ b/holoviews/plotting/plotly/util.py
@@ -654,9 +654,11 @@ def get_colorscale(cmap, levels=None, cmin=None, cmax=None):
     try:
         palette = process_cmap(cmap, ncolors)
     except Exception as e:
-        palette = colors.PLOTLY_SCALES.get(cmap)
-        if palette is None:
+        colorscale = colors.PLOTLY_SCALES.get(cmap)
+        if colorscale is None:
             raise e
+        return colorscale
+
     if isinstance(levels, int):
         colorscale = []
         scale = np.linspace(0, 1, levels+1)

--- a/holoviews/tests/plotting/plotly/testbivariateplot.py
+++ b/holoviews/tests/plotting/plotly/testbivariateplot.py
@@ -22,9 +22,22 @@ class TestBivariatePlot(TestPlotlyPlot):
             filled=True)
         state = self._get_plot_state(bivariate)
         self.assertEqual(state['data'][0]['contours']['coloring'], 'fill')
-    
+
     def test_bivariate_ncontours(self):
         bivariate = Bivariate(([3, 2, 1], [0, 1, 2])).options(ncontours=5)
         state = self._get_plot_state(bivariate)
         self.assertEqual(state['data'][0]['ncontours'], 5)
         self.assertEqual(state['data'][0]['autocontour'], False)
+
+    def test_bivariate_colorbar(self):
+        bivariate = Bivariate(([3, 2, 1], [0, 1, 2]))\
+
+        bivariate.opts(colorbar=True)
+        state = self._get_plot_state(bivariate)
+        trace = state['data'][0]
+        self.assertTrue(trace['showscale'])
+
+        bivariate.opts(colorbar=False)
+        state = self._get_plot_state(bivariate)
+        trace = state['data'][0]
+        self.assertFalse(trace['showscale'])

--- a/holoviews/tests/plotting/plotly/testsurfaceplot.py
+++ b/holoviews/tests/plotting/plotly/testsurfaceplot.py
@@ -19,3 +19,15 @@ class TestSurfacePlot(TestPlotlyPlot):
         self.assertEqual(state['layout']['scene']['xaxis']['range'], [0.5, 3.5])
         self.assertEqual(state['layout']['scene']['yaxis']['range'], [-0.5, 1.5])
         self.assertEqual(state['layout']['scene']['zaxis']['range'], [0, 4])
+
+    def test_surface_colorbar(self):
+        img = Surface(([1, 2, 3], [0, 1], np.array([[0, 1, 2], [2, 3, 4]])))
+        img.opts(colorbar=True)
+        state = self._get_plot_state(img)
+        trace = state['data'][0]
+        self.assertTrue(trace['showscale'])
+
+        img.opts(colorbar=False)
+        state = self._get_plot_state(img)
+        trace = state['data'][0]
+        self.assertFalse(trace['showscale'])


### PR DESCRIPTION
This PR includes various fixes related to colorscale/colorbar handling for the plotly backend

Commit summary:
 - 8eb78b0: This addresses #3414 by limiting the length of colorscales passed to plotly.js to a maximum of 255.  Longer colorscales are subsampled.  Plotly.js performs its own colorscale interpolation so I don't foresee this causing visual artifacts for any reasonably smooth colorscale.
```python
import numpy as np
import holoviews as hv
from holoviews import dim
from holoviews import opts
hv.extension('plotly')

surface = hv.Surface(np.sin(np.linspace(0,100*np.pi*2,10000)).reshape(100,100))
surface.opts(cmap='fire', height=500, width=500, colorbar=True)
```
![newplot-1](https://user-images.githubusercontent.com/15064365/55282012-295d2e00-5312-11e9-9e45-82ab80fd9ff1.png)

 - 1ffdef1: Fix for the case where a named colorscale is known only to plotly.py.  Previously this resulted in a malformed colorscale.

```python
surface = hv.Surface(np.sin(np.linspace(0,100*np.pi*2,10000)).reshape(100,100))
surface.opts(cmap='Picnic', height=500, width=500, colorbar=True)
```
![newplot-2](https://user-images.githubusercontent.com/15064365/55282023-5ad5f980-5312-11e9-86d0-e02d86fc0268.png)

 - 9cc745b:  Fixes `colorbar` and `edges_color` handling.  Both of these options are applied to separate traces (separate from the main `mesh3d` trace) which were being dropped.  With these changes, an `Element` may be represented by a series of traces instead of only 1.

```python
y,x = np.mgrid[-5:5, -5:5] * 0.1
heights = np.sin(x**2+y**2)
trisurface = hv.TriSurface((x.flat,y.flat,heights.flat))

trisurface.opts(height=500, width=500, cmap='plasma', colorbar=True, edges_color='cyan')
```
![newplot-3](https://user-images.githubusercontent.com/15064365/55282037-ac7e8400-5312-11e9-9c3e-0420cf178a2c.png)

 - `016a137`: Add/fix colorbar/colorscale handling for the plotly bivariate element.  Previously, the `cmap` and `colorbar` args were ignored.
```python
normal = np.random.randn(1000, 2)
biv = hv.Bivariate(normal)
biv.opts(filled=True, cmap='cividis', showlines=True, colorbar=True)
```
![newplot-4](https://user-images.githubusercontent.com/15064365/55282049-dc2d8c00-5312-11e9-926c-ba29e6dbcd70.png)

```python
normal = np.random.randn(1000, 2)
biv = hv.Bivariate(normal)
biv.opts(filled=False, cmap='plasma', showlines=True, colorbar=True)
```
![newplot-5](https://user-images.githubusercontent.com/15064365/55282060-0a12d080-5313-11e9-83a2-9441be6712b9.png)
 - I tried out the colorbar/colorscale handling of other `Elements` and the rest of them worked fine.
 - 8fb44d8:  Adds a few additional colorbar test cases