### PR TITLE
Updated tests after changes in param formatting

### DIFF
--- a/holoviews/tests/plotting/bokeh/testbarplot.py
+++ b/holoviews/tests/plotting/bokeh/testbarplot.py
@@ -244,7 +244,7 @@ class TestBarPlot(TestBokehPlot):
         bars = Bars([(0, 0, 0), (0, 1, 1), (0, 2, 2)],
                     vdims=['y', 'color']).options(color='color', color_index='color')
         with ParamLogStream() as log:
-            plot = bokeh_renderer.get_plot(bars)
+            bokeh_renderer.get_plot(bars)
         log_msg = log.stream.read()
         warning = ("Cannot declare style mapping for 'color' option "
                    "and declare a color_index; ignoring the color_index.\n")

--- a/holoviews/tests/plotting/bokeh/testbarplot.py
+++ b/holoviews/tests/plotting/bokeh/testbarplot.py
@@ -246,7 +246,6 @@ class TestBarPlot(TestBokehPlot):
         with ParamLogStream() as log:
             plot = bokeh_renderer.get_plot(bars)
         log_msg = log.stream.read()
-        warning = ("%s: Cannot declare style mapping for 'color' option "
-                   "and declare a color_index; ignoring the color_index.\n"
-                   % plot.name)
+        warning = ("Cannot declare style mapping for 'color' option "
+                   "and declare a color_index; ignoring the color_index.\n")
         self.assertEqual(log_msg, warning)

--- a/holoviews/tests/plotting/bokeh/testlabels.py
+++ b/holoviews/tests/plotting/bokeh/testlabels.py
@@ -179,7 +179,7 @@ class TestLabelsPlot(TestBokehPlot):
         labels = Labels([(0, 0, 0), (0, 1, 1), (0, 2, 2)],
                         vdims='color').options(text_color='color', color_index='color')        
         with ParamLogStream() as log:
-            plot = bokeh_renderer.get_plot(labels)
+            bokeh_renderer.get_plot(labels)
         log_msg = log.stream.read()
         warning = ("Cannot declare style mapping for 'text_color' option "
                    "and declare a color_index; ignoring the color_index.\n")

--- a/holoviews/tests/plotting/bokeh/testlabels.py
+++ b/holoviews/tests/plotting/bokeh/testlabels.py
@@ -181,7 +181,6 @@ class TestLabelsPlot(TestBokehPlot):
         with ParamLogStream() as log:
             plot = bokeh_renderer.get_plot(labels)
         log_msg = log.stream.read()
-        warning = ("%s: Cannot declare style mapping for 'text_color' option "
-                   "and declare a color_index; ignoring the color_index.\n"
-                   % plot.name)
+        warning = ("Cannot declare style mapping for 'text_color' option "
+                   "and declare a color_index; ignoring the color_index.\n")
         self.assertEqual(log_msg, warning)

--- a/holoviews/tests/plotting/bokeh/testpointplot.py
+++ b/holoviews/tests/plotting/bokeh/testpointplot.py
@@ -169,8 +169,8 @@ class TestPointPlot(TestBokehPlot):
         with ParamLogStream() as log:
             plot = bokeh_renderer.get_plot(points)
         log_msg = log.stream.read()
-        warning = ('%s: z dimension is not numeric, '
-                   'cannot use to scale Points size.\n' % plot.name)
+        warning = ('z dimension is not numeric, '
+                   'cannot use to scale Points size.\n')
         self.assertEqual(log_msg, warning)
 
     def test_points_categorical_xaxis(self):
@@ -476,9 +476,8 @@ class TestPointPlot(TestBokehPlot):
         with ParamLogStream() as log:
             plot = bokeh_renderer.get_plot(points)
         log_msg = log.stream.read()
-        warning = ("%s: Cannot declare style mapping for 'color' option "
-                   "and declare a color_index; ignoring the color_index.\n"
-                   % plot.name)
+        warning = ("Cannot declare style mapping for 'color' option "
+                   "and declare a color_index; ignoring the color_index.\n")
         self.assertEqual(log_msg, warning)
 
     def test_point_color_index_color_no_clash(self):
@@ -497,7 +496,6 @@ class TestPointPlot(TestBokehPlot):
         with ParamLogStream() as log:
             plot = bokeh_renderer.get_plot(points)
         log_msg = log.stream.read()
-        warning = ("%s: Cannot declare style mapping for 'size' option "
-                   "and declare a size_index; ignoring the size_index.\n"
-                   % plot.name)
+        warning = ("Cannot declare style mapping for 'size' option "
+                   "and declare a size_index; ignoring the size_index.\n")
         self.assertEqual(log_msg, warning)

--- a/holoviews/tests/plotting/bokeh/testpointplot.py
+++ b/holoviews/tests/plotting/bokeh/testpointplot.py
@@ -167,7 +167,7 @@ class TestPointPlot(TestBokehPlot):
         data = (np.arange(10), np.arange(10), list(map(chr, range(94,104))))
         points = Points(data, vdims=['z']).opts(plot=dict(size_index=2))
         with ParamLogStream() as log:
-            plot = bokeh_renderer.get_plot(points)
+            bokeh_renderer.get_plot(points)
         log_msg = log.stream.read()
         warning = ('z dimension is not numeric, '
                    'cannot use to scale Points size.\n')
@@ -474,7 +474,7 @@ class TestPointPlot(TestBokehPlot):
         points = Points([(0, 0, 0), (0, 1, 1), (0, 2, 2)],
                         vdims='color').options(color='color', color_index='color')        
         with ParamLogStream() as log:
-            plot = bokeh_renderer.get_plot(points)
+            bokeh_renderer.get_plot(points)
         log_msg = log.stream.read()
         warning = ("Cannot declare style mapping for 'color' option "
                    "and declare a color_index; ignoring the color_index.\n")
@@ -494,7 +494,7 @@ class TestPointPlot(TestBokehPlot):
         points = Points([(0, 0, 0), (0, 1, 1), (0, 2, 2)],
                         vdims='size').options(size='size', size_index='size')        
         with ParamLogStream() as log:
-            plot = bokeh_renderer.get_plot(points)
+            bokeh_renderer.get_plot(points)
         log_msg = log.stream.read()
         warning = ("Cannot declare style mapping for 'size' option "
                    "and declare a size_index; ignoring the size_index.\n")

--- a/holoviews/tests/plotting/bokeh/testspikesplot.py
+++ b/holoviews/tests/plotting/bokeh/testspikesplot.py
@@ -218,7 +218,6 @@ class TestSpikesPlot(TestBokehPlot):
         with ParamLogStream() as log:
             plot = bokeh_renderer.get_plot(spikes)
         log_msg = log.stream.read()
-        warning = ("%s: Cannot declare style mapping for 'color' option "
-                   "and declare a color_index; ignoring the color_index.\n"
-                   % plot.name)
+        warning = ("Cannot declare style mapping for 'color' option "
+                   "and declare a color_index; ignoring the color_index.\n")
         self.assertEqual(log_msg, warning)

--- a/holoviews/tests/plotting/bokeh/testspikesplot.py
+++ b/holoviews/tests/plotting/bokeh/testspikesplot.py
@@ -216,7 +216,7 @@ class TestSpikesPlot(TestBokehPlot):
         spikes = Spikes([(0, 0, 0), (0, 1, 1), (0, 2, 2)],
                     vdims=['y', 'color']).options(color='color', color_index='color')
         with ParamLogStream() as log:
-            plot = bokeh_renderer.get_plot(spikes)
+            bokeh_renderer.get_plot(spikes)
         log_msg = log.stream.read()
         warning = ("Cannot declare style mapping for 'color' option "
                    "and declare a color_index; ignoring the color_index.\n")

--- a/holoviews/tests/plotting/bokeh/testvectorfieldplot.py
+++ b/holoviews/tests/plotting/bokeh/testvectorfieldplot.py
@@ -76,7 +76,6 @@ class TestVectorFieldPlot(TestBokehPlot):
         with ParamLogStream() as log:
             plot = bokeh_renderer.get_plot(vectorfield)
         log_msg = log.stream.read()
-        warning = ("%s: Cannot declare style mapping for 'line_color' option "
-                   "and declare a color_index; ignoring the color_index.\n"
-                   % plot.name)
+        warning = ("Cannot declare style mapping for 'line_color' option "
+                   "and declare a color_index; ignoring the color_index.\n")
         self.assertEqual(log_msg, warning)

--- a/holoviews/tests/plotting/bokeh/testvectorfieldplot.py
+++ b/holoviews/tests/plotting/bokeh/testvectorfieldplot.py
@@ -74,7 +74,7 @@ class TestVectorFieldPlot(TestBokehPlot):
         vectorfield = VectorField([(0, 0, 0), (0, 1, 1), (0, 2, 2)],
                         vdims='color').options(line_color='color', color_index='color')        
         with ParamLogStream() as log:
-            plot = bokeh_renderer.get_plot(vectorfield)
+            bokeh_renderer.get_plot(vectorfield)
         log_msg = log.stream.read()
         warning = ("Cannot declare style mapping for 'line_color' option "
                    "and declare a color_index; ignoring the color_index.\n")

--- a/holoviews/tests/plotting/matplotlib/testpointplot.py
+++ b/holoviews/tests/plotting/matplotlib/testpointplot.py
@@ -19,7 +19,7 @@ class TestPointPlot(TestMPLPlot):
         data = (np.arange(10), np.arange(10), list(map(chr, range(94,104))))
         points = Points(data, vdims=['z']).opts(plot=dict(size_index=2))
         with ParamLogStream() as log:
-            plot = mpl_renderer.get_plot(points)
+            mpl_renderer.get_plot(points)
         log_msg = log.stream.read()
         warning = ('z dimension is not numeric, '
                    'cannot use to scale Points size.\n')
@@ -303,7 +303,7 @@ class TestPointPlot(TestMPLPlot):
         points = Points([(0, 0, 0), (0, 1, 1), (0, 2, 2)],
                         vdims='color').options(color='color', color_index='color')
         with ParamLogStream() as log:
-            plot = mpl_renderer.get_plot(points)
+            mpl_renderer.get_plot(points)
         log_msg = log.stream.read()
         warning = ("Cannot declare style mapping for 'color' option "
                    "and declare a color_index; ignoring the color_index.\n")
@@ -313,7 +313,7 @@ class TestPointPlot(TestMPLPlot):
         points = Points([(0, 0, 0), (0, 1, 1), (0, 2, 2)],
                         vdims='size').options(s='size', size_index='size')
         with ParamLogStream() as log:
-            plot = mpl_renderer.get_plot(points)
+            mpl_renderer.get_plot(points)
         log_msg = log.stream.read()
         warning = ("Cannot declare style mapping for 's' option "
                    "and declare a size_index; ignoring the size_index.\n")

--- a/holoviews/tests/plotting/matplotlib/testpointplot.py
+++ b/holoviews/tests/plotting/matplotlib/testpointplot.py
@@ -21,8 +21,8 @@ class TestPointPlot(TestMPLPlot):
         with ParamLogStream() as log:
             plot = mpl_renderer.get_plot(points)
         log_msg = log.stream.read()
-        warning = ('%s: z dimension is not numeric, '
-                   'cannot use to scale Points size.\n' % plot.name)
+        warning = ('z dimension is not numeric, '
+                   'cannot use to scale Points size.\n')
         self.assertEqual(log_msg, warning)
 
     def test_points_cbar_extend_both(self):
@@ -305,9 +305,8 @@ class TestPointPlot(TestMPLPlot):
         with ParamLogStream() as log:
             plot = mpl_renderer.get_plot(points)
         log_msg = log.stream.read()
-        warning = ("%s: Cannot declare style mapping for 'color' option "
-                   "and declare a color_index; ignoring the color_index.\n"
-                   % plot.name)
+        warning = ("Cannot declare style mapping for 'color' option "
+                   "and declare a color_index; ignoring the color_index.\n")
         self.assertEqual(log_msg, warning)
 
     def test_point_size_index_size_clash(self):
@@ -316,7 +315,6 @@ class TestPointPlot(TestMPLPlot):
         with ParamLogStream() as log:
             plot = mpl_renderer.get_plot(points)
         log_msg = log.stream.read()
-        warning = ("%s: Cannot declare style mapping for 's' option "
-                   "and declare a size_index; ignoring the size_index.\n"
-                   % plot.name)
+        warning = ("Cannot declare style mapping for 's' option "
+                   "and declare a size_index; ignoring the size_index.\n")
         self.assertEqual(log_msg, warning)

--- a/holoviews/tests/plotting/matplotlib/testspikeplot.py
+++ b/holoviews/tests/plotting/matplotlib/testspikeplot.py
@@ -192,7 +192,7 @@ class TestSpikesPlot(TestMPLPlot):
         spikes = Spikes([(0, 0, 0), (0, 1, 1), (0, 2, 2)],
                         vdims=['y', 'color']).options(color='color', color_index='color')
         with ParamLogStream() as log:
-            plot = mpl_renderer.get_plot(spikes)
+            mpl_renderer.get_plot(spikes)
         log_msg = log.stream.read()
         warning = ("Cannot declare style mapping for 'color' option "
                    "and declare a color_index; ignoring the color_index.\n")

--- a/holoviews/tests/plotting/matplotlib/testspikeplot.py
+++ b/holoviews/tests/plotting/matplotlib/testspikeplot.py
@@ -194,8 +194,7 @@ class TestSpikesPlot(TestMPLPlot):
         with ParamLogStream() as log:
             plot = mpl_renderer.get_plot(spikes)
         log_msg = log.stream.read()
-        warning = ("%s: Cannot declare style mapping for 'color' option "
-                   "and declare a color_index; ignoring the color_index.\n"
-                   % plot.name)
+        warning = ("Cannot declare style mapping for 'color' option "
+                   "and declare a color_index; ignoring the color_index.\n")
         self.assertEqual(log_msg, warning)
 

--- a/holoviews/tests/plotting/matplotlib/testvectorfieldplot.py
+++ b/holoviews/tests/plotting/matplotlib/testvectorfieldplot.py
@@ -95,7 +95,7 @@ class TestVectorFieldPlot(TestMPLPlot):
         vectorfield = VectorField([(0, 0, 0, 1, 0), (0, 1, 0, 1, 1), (0, 2, 0, 1, 2)],
                                   vdims=['A', 'M', 'color']).options(color='color', color_index='A')
         with ParamLogStream() as log:
-            plot = mpl_renderer.get_plot(vectorfield)
+            mpl_renderer.get_plot(vectorfield)
         log_msg = log.stream.read()
         warning = ("Cannot declare style mapping for 'color' option "
                    "and declare a color_index; ignoring the color_index.\n")

--- a/holoviews/tests/plotting/matplotlib/testvectorfieldplot.py
+++ b/holoviews/tests/plotting/matplotlib/testvectorfieldplot.py
@@ -97,7 +97,6 @@ class TestVectorFieldPlot(TestMPLPlot):
         with ParamLogStream() as log:
             plot = mpl_renderer.get_plot(vectorfield)
         log_msg = log.stream.read()
-        warning = ("%s: Cannot declare style mapping for 'color' option "
-                   "and declare a color_index; ignoring the color_index.\n"
-                   % plot.name)
+        warning = ("Cannot declare style mapping for 'color' option "
+                   "and declare a color_index; ignoring the color_index.\n")
         self.assertEqual(log_msg, warning)


### PR DESCRIPTION
This PR updates tests to match the changed formatting in the latest param dev release. While it fixes the test errors the param change also revealed the fact that the tests seem to have suppressed warnings entirely in the past, which is no longer the case now. We should work on either fixing the warning or suppress them where needed but that can happen in a subsequent PR.