### PR TITLE
Remove hardcoding of lightgray fill color to box and violin

### DIFF
--- a/holoviews/plotting/bokeh/__init__.py
+++ b/holoviews/plotting/bokeh/__init__.py
@@ -161,7 +161,7 @@ options = Store.options(backend='bokeh')
 
 # Charts
 options.Curve = Options('style', color=Cycle(), line_width=2)
-options.BoxWhisker = Options('style', box_fill_color='lightgray', whisker_color='black',
+options.BoxWhisker = Options('style', box_fill_color=Cycle(), whisker_color='black',
                              box_line_color='black', outlier_color='black')
 options.Scatter = Options('style', color=Cycle(), size=point_size, cmap=dflt_cmap)
 options.Points = Options('style', color=Cycle(), size=point_size, cmap=dflt_cmap)
@@ -274,7 +274,7 @@ options.Distribution = Options(
     muted_alpha=0.2
 )
 options.Violin = Options(
-    'style', violin_fill_color='lightgray', violin_line_color='black',
+    'style', violin_fill_color=Cycle(), violin_line_color='black',
     violin_fill_alpha=0.5, stats_color='black', box_color='black',
     median_color='white'
 )


### PR DESCRIPTION
Setting it to Cycle() now makes overlaying color cycle as expected
![image](https://user-images.githubusercontent.com/15331990/55373733-fa35f080-54ba-11e9-994a-d328c1300078.png)

Reverses https://github.com/pyviz/holoviews/pull/2975, but the cycling of these color is redundant of the x-axis 
![image](https://user-images.githubusercontent.com/15331990/55373890-80eacd80-54bb-11e9-9504-d9caa7e2a82a.png)


