### PR TITLE
Allow ability to define style cycles for Draw tools 

### DIFF
--- a/examples/reference/streams/bokeh/BoxEdit.ipynb
+++ b/examples/reference/streams/bokeh/BoxEdit.ipynb
@@ -42,7 +42,13 @@
     "\n",
     "**Delete box**\n",
     "\n",
-    "    Tap a box to select it then press BACKSPACE key while the mouse is within the plot area."
+    "    Tap a box to select it then press BACKSPACE key while the mouse is within the plot area.\n",
+    "    \n",
+    "### Properties\n",
+    "\n",
+    "* **``empty_value``**: Value to add to non-coordinate columns when adding new box\n",
+    "* **``num_objects``** (int): Maximum number of boxes to draw before deleting the oldest object\n",
+    "* **``styles``** (dict): Dictionary of style properties (e.g. line_color, line_width etc.) to apply to each box. If values are lists the values will cycle over the values."
    ]
   },
   {
@@ -59,7 +65,7 @@
    "outputs": [],
    "source": [
     "boxes = hv.Polygons([hv.Box(0, 0, 1), hv.Box(2, 1, 1.5), hv.Box(0.5, 1.5, 1)])\n",
-    "box_stream = streams.BoxEdit(source=boxes, num_objects=2)\n",
+    "box_stream = streams.BoxEdit(source=boxes, num_objects=3, styles={'fill_color': ['red', 'green', 'blue']})\n",
     "boxes.opts(\n",
     "    opts.Polygons(active_tools=['box_edit'], fill_alpha=0.5, height=400, width=400))"
    ]

--- a/examples/reference/streams/bokeh/FreehandDraw.ipynb
+++ b/examples/reference/streams/bokeh/FreehandDraw.ipynb
@@ -26,6 +26,12 @@
     "\n",
     "    Tap a line to select it then press BACKSPACE key while the mouse is within the plot area.\n",
     "    \n",
+    "### Properties\n",
+    "\n",
+    "* **``empty_value``**: Value to add to non-coordinate columns when adding new path\n",
+    "* **``num_objects``** (int): Maximum number of paths to draw before deleting the oldest object\n",
+    "* **``styles``** (dict): Dictionary of style properties (e.g. line_color, line_width etc.) to apply to each path. If values are lists the values will cycle over the values.\n",
+    "    \n",
     "The tool allows drawing lines and polygons by supplying it with a ``Path`` or ``Polygons`` object as a source. It also allows limiting the number of lines or polygons that can be drawn by setting ``num_objects`` to a finite number, causing the first line to be dropped when the limit is reached."
    ]
   },
@@ -36,7 +42,8 @@
    "outputs": [],
    "source": [
     "path = hv.Path([])\n",
-    "freehand = streams.FreehandDraw(source=path, num_objects=3)\n",
+    "freehand = streams.FreehandDraw(source=path, num_objects=3,\n",
+    "                                styles={'line_color': ['red', 'green', 'blue']})\n",
     "\n",
     "path.opts(\n",
     "    opts.Path(active_tools=['freehand_draw'], height=400, line_width=10, width=400))"

--- a/examples/reference/streams/bokeh/PolyDraw.ipynb
+++ b/examples/reference/streams/bokeh/PolyDraw.ipynb
@@ -42,7 +42,16 @@
     "\n",
     "**Delete patch/multi-line**\n",
     "\n",
-    "    Tap a patch/multi-line to select it then press BACKSPACE key while the mouse is within the plot area."
+    "    Tap a patch/multi-line to select it then press BACKSPACE key while the mouse is within the plot area.\n",
+    "    \n",
+    "### Properties\n",
+    "\n",
+    "* **``drag``** (boolean): Whether to enable dragging of paths and polygons\n",
+    "* **``empty_value``**: Value to add to non-coordinate columns when adding new path or polygon\n",
+    "* **``num_objects``** (int): Maximum number of paths or polygons to draw before deleting the oldest object\n",
+    "* **``show_vertices``** (boolean): Whether to show the vertices of the paths or polygons\n",
+    "* **``styles``** (dict): Dictionary of style properties (e.g. line_color, line_width etc.) to apply to each path and polygon. If values are lists the values will cycle over the values) \n",
+    "* **``vertex_style``** (dict): Dictionary of style properties (e.g. fill_color, line_width etc.) to apply to vertices if ``show_vertices`` enabled"
    ]
   },
   {
@@ -61,7 +70,10 @@
     "path = hv.Path([[(1, 5), (9, 5)]])\n",
     "poly = hv.Polygons([[(2, 2), (5, 8), (8, 2)]])\n",
     "path_stream = streams.PolyDraw(source=path, drag=True, show_vertices=True)\n",
-    "poly_stream = streams.PolyDraw(source=poly, drag=True, num_objects=2, show_vertices=True)\n",
+    "poly_stream = streams.PolyDraw(source=poly, drag=True, num_objects=4,\n",
+    "                               show_vertices=True, styles={\n",
+    "                                   'fill_color': ['red', 'green', 'blue']\n",
+    "                               })\n",
     "\n",
     "(path * poly).opts(\n",
     "    opts.Path(color='red', height=400, line_width=5, width=400),\n",

--- a/holoviews/plotting/bokeh/callbacks.py
+++ b/holoviews/plotting/bokeh/callbacks.py
@@ -947,22 +947,11 @@ class CDSCallback(Callback):
 class PointDrawCallback(CDSCallback):
 
     def initialize(self, plot_id=None):
-        try:
-            from bokeh.models import PointDrawTool
-        except Exception:
-            param.main.param.warning('PointDraw requires bokeh >= 0.12.14')
-            return
-
         stream = self.streams[0]
         renderers = [self.plot.handles['glyph_renderer']]
         kwargs = {}
         if stream.num_objects:
-            if bokeh_version >= '1.0.0':
-                kwargs['num_objects'] = stream.num_objects
-            else:
-                param.main.param.warning(
-                    'Specifying num_objects to PointDraw stream requires '
-                    'a bokeh version >= 1.0.0.')
+            kwargs['num_objects'] = stream.num_objects
         point_tool = PointDrawTool(drag=all(s.drag for s in self.streams),
                                    empty_value=stream.empty_value,
                                    renderers=renderers, **kwargs)
@@ -982,30 +971,15 @@ class PointDrawCallback(CDSCallback):
 class PolyDrawCallback(CDSCallback):
 
     def initialize(self, plot_id=None):
-        try:
-            from bokeh.models import PolyDrawTool
-        except:
-            param.main.param.warning('PolyDraw requires bokeh >= 0.12.14')
-            return
         plot = self.plot
         stream = self.streams[0]
         kwargs = {}
         if stream.num_objects:
-            if bokeh_version >= '1.0.0':
-                kwargs['num_objects'] = stream.num_objects
-            else:
-                param.main.param.warning(
-                    'Specifying num_objects to PointDraw stream requires '
-                    'a bokeh version >=1.0.0.')
+            kwargs['num_objects'] = stream.num_objects
         if stream.show_vertices:
-            if bokeh_version >= '1.0.0':
-                vertex_style = dict({'size': 10}, **stream.vertex_style)
-                r1 = plot.state.scatter([], [], **vertex_style)
-                kwargs['vertex_renderer'] = r1
-            else:
-                param.main.param.warning(
-                    'Enabling vertices on the PointDraw stream requires '
-                    'a bokeh version >=1.0.0.')
+            vertex_style = dict({'size': 10}, **stream.vertex_style)
+            r1 = plot.state.scatter([], [], **vertex_style)
+            kwargs['vertex_renderer'] = r1
         poly_tool = PolyDrawTool(drag=all(s.drag for s in self.streams),
                                  empty_value=stream.empty_value,
                                  renderers=[plot.handles['glyph_renderer']],
@@ -1032,11 +1006,6 @@ class PolyDrawCallback(CDSCallback):
 class FreehandDrawCallback(PolyDrawCallback):
 
     def initialize(self, plot_id=None):
-        try:
-            from bokeh.models import FreehandDrawTool
-        except:
-            param.main.param.warning('FreehandDraw requires bokeh >= 0.13.0')
-            return
         plot = self.plot
         stream = self.streams[0]
         poly_tool = FreehandDrawTool(
@@ -1055,24 +1024,13 @@ class BoxEditCallback(CDSCallback):
     models = ['rect_source']
 
     def initialize(self, plot_id=None):
-        try:
-            from bokeh.models import BoxEditTool
-        except:
-            param.main.param.warning('BoxEdit requires bokeh >= 0.12.14')
-            return
-
         plot = self.plot
         data = plot.handles['cds'].data
         element = self.plot.current_frame
         stream = self.streams[0]
         kwargs = {}
         if stream.num_objects:
-            if bokeh_version >= '1.0.0':
-                kwargs['num_objects'] = stream.num_objects
-            else:
-                param.main.param.warning(
-                    'Specifying num_objects to BoxEdit stream requires '
-                    'a bokeh version >=1.0.0.')
+            kwargs['num_objects'] = stream.num_objects
         xs, ys, widths, heights = [], [], [], []
         for x, y in zip(data['xs'], data['ys']):
             x0, x1 = (np.nanmin(x), np.nanmax(x))
@@ -1115,11 +1073,6 @@ class BoxEditCallback(CDSCallback):
 class PolyEditCallback(PolyDrawCallback):
 
     def initialize(self, plot_id=None):
-        try:
-            from bokeh.models import PolyEditTool
-        except:
-            param.main.param.warning('PolyEdit requires bokeh >= 0.12.14')
-            return
         plot = self.plot
         vertex_tool = None
         if all(s.shared for s in self.streams):

--- a/holoviews/plotting/bokeh/callbacks.py
+++ b/holoviews/plotting/bokeh/callbacks.py
@@ -21,7 +21,7 @@ from ...streams import (Stream, PointerXY, RangeXY, Selection1D, RangeX,
                         FreehandDraw)
 from ..links import Link, RangeToolLink, DataLink
 from ..plot import GenericElementPlot, GenericOverlayPlot
-from .util import convert_timestamp, bokeh_version
+from .util import convert_timestamp
 
 
 class MessageCallback(object):
@@ -946,7 +946,7 @@ class CDSCallback(Callback):
         return msg
 
 
-class DrawCallback(CDSCallback):
+class GlyphDrawCallback(CDSCallback):
 
     _style_callback = """
       var length = cb_obj.data['xs'].length;
@@ -998,7 +998,7 @@ class PointDrawCallback(CDSCallback):
         super(PointDrawCallback, self).initialize(plot_id)
 
 
-class PolyDrawCallback(DrawCallback):
+class PolyDrawCallback(GlyphDrawCallback):
 
     def initialize(self, plot_id=None):
         plot = self.plot

--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -1065,11 +1065,16 @@ class FreehandDraw(CDSStream):
     num_objects: int
         The number of polygons that can be drawn before overwriting
         the oldest polygon.
+
+    style_cycles: dict
+        A dictionary specifying lists of styles to cycle over whenever
+        a new freehand glyph is drawn.
     """
 
-    def __init__(self, empty_value=None, num_objects=0, **params):
+    def __init__(self, empty_value=None, num_objects=0, style_cycles={}, **params):
         self.empty_value = empty_value
         self.num_objects = num_objects
+        self.style_cycles = style_cycles
         super(FreehandDraw, self).__init__(**params)
 
     @property
@@ -1091,20 +1096,29 @@ class FreehandDraw(CDSStream):
     def dynamic(self):
         from .core.spaces import DynamicMap
         return DynamicMap(lambda *args, **kwargs: self.element, streams=[self])
-    
+
 
 
 class BoxEdit(CDSStream):
     """
     Attaches a BoxEditTool and syncs the datasource.
 
+    empty_value: int/float/string/None
+        The value to insert on non-position columns when adding a new box
+
     num_objects: int
         The number of boxes that can be drawn before overwriting the
         oldest drawn box.
+
+    style_cycles: dict
+        A dictionary specifying lists of styles to cycle over whenever
+        a new box glyph is drawn.
     """
 
-    def __init__(self, num_objects=0, **params):
+    def __init__(self, empty_value=None, num_objects=0, style_cycles={}, **params):
+        self.empty_value = empty_value
         self.num_objects = num_objects
+        self.style_cycles = style_cycles
         super(BoxEdit, self).__init__(**params)
 
     @property

--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -1018,20 +1018,20 @@ class PolyDraw(CDSStream):
         The usual bokeh style options apply, e.g. fill_color,
         line_alpha, size, etc.
 
-    style_cycles: dict
+    styles: dict
         A dictionary specifying lists of styles to cycle over whenever
         a new Poly glyph is drawn.
     """
 
     def __init__(self, empty_value=None, drag=True, num_objects=0,
-                 show_vertices=False, vertex_style={}, style_cycles={},
+                 show_vertices=False, vertex_style={}, styles={},
                  **params):
         self.drag = drag
         self.empty_value = empty_value
         self.num_objects = num_objects
         self.show_vertices = show_vertices
         self.vertex_style = vertex_style
-        self.style_cycles = style_cycles
+        self.styles = styles
         super(PolyDraw, self).__init__(**params)
 
     @property
@@ -1066,15 +1066,15 @@ class FreehandDraw(CDSStream):
         The number of polygons that can be drawn before overwriting
         the oldest polygon.
 
-    style_cycles: dict
+    styles: dict
         A dictionary specifying lists of styles to cycle over whenever
         a new freehand glyph is drawn.
     """
 
-    def __init__(self, empty_value=None, num_objects=0, style_cycles={}, **params):
+    def __init__(self, empty_value=None, num_objects=0, styles={}, **params):
         self.empty_value = empty_value
         self.num_objects = num_objects
-        self.style_cycles = style_cycles
+        self.styles = styles
         super(FreehandDraw, self).__init__(**params)
 
     @property
@@ -1110,15 +1110,15 @@ class BoxEdit(CDSStream):
         The number of boxes that can be drawn before overwriting the
         oldest drawn box.
 
-    style_cycles: dict
+    styles: dict
         A dictionary specifying lists of styles to cycle over whenever
         a new box glyph is drawn.
     """
 
-    def __init__(self, empty_value=None, num_objects=0, style_cycles={}, **params):
+    def __init__(self, empty_value=None, num_objects=0, styles={}, **params):
         self.empty_value = empty_value
         self.num_objects = num_objects
-        self.style_cycles = style_cycles
+        self.styles = styles
         super(BoxEdit, self).__init__(**params)
 
     @property

--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -1017,15 +1017,21 @@ class PolyDraw(CDSStream):
         A dictionary specifying the style options for the vertices.
         The usual bokeh style options apply, e.g. fill_color,
         line_alpha, size, etc.
+
+    style_cycles: dict
+        A dictionary specifying lists of styles to cycle over whenever
+        a new Poly glyph is drawn.
     """
 
     def __init__(self, empty_value=None, drag=True, num_objects=0,
-                 show_vertices=False, vertex_style={}, **params):
+                 show_vertices=False, vertex_style={}, style_cycles={},
+                 **params):
         self.drag = drag
         self.empty_value = empty_value
         self.num_objects = num_objects
         self.show_vertices = show_vertices
         self.vertex_style = vertex_style
+        self.style_cycles = style_cycles
         super(PolyDraw, self).__init__(**params)
 
     @property


### PR DESCRIPTION
This PR allows adding style cycles to the PolyDraw stream (but this could be expanded to the other draw streams). As an example here we cycle over the fill_color and line_width of the drawn polygons:

```python
poly = hv.Polygons([[(2, 2), (5, 8), (8, 2)]])

poly_stream = streams.PolyDraw(source=poly, drag=True, show_vertices=True,
                               style_cycles={'fill_color': ['red', 'green', 'blue'],
                                             'line_width': [3, 5, 10]})

poly
```

![style_cycles](https://user-images.githubusercontent.com/1550771/55795698-4f2bc500-5ac0-11e9-9d4a-749db73b47ec.gif)

- [x] Fixes https://github.com/pyviz/holoviews/issues/2694
- [x] Expand to BoxEdit and FreehandDraw tools
- [x] Add example in documentation