### PR TITLE
Plotly 3.8 support

### DIFF
--- a/holoviews/plotting/plotly/element.py
+++ b/holoviews/plotting/plotly/element.py
@@ -10,7 +10,8 @@ from ...util.transform import dim
 from ..plot import GenericElementPlot, GenericOverlayPlot
 from ..util import dim_range_key, dynamic_update
 from .plot import PlotlyPlot
-from .util import STYLE_ALIASES, get_colorscale, merge_figure
+from .util import (
+    STYLE_ALIASES, get_colorscale, merge_figure, legend_trace_types)
 
 
 class ElementPlot(PlotlyPlot, GenericElementPlot):
@@ -158,8 +159,11 @@ class ElementPlot(PlotlyPlot, GenericElementPlot):
             legend = element.label
 
         opts = dict(
-            showlegend=self.show_legend, legendgroup=element.group,
             name=legend, **self.trace_kwargs)
+
+        if self.trace_kwargs.get('type', None) in legend_trace_types:
+            opts.update(
+                showlegend=self.show_legend, legendgroup=element.group)
 
         if self._style_key is not None:
             styles = self._apply_transforms(element, ranges, style)

--- a/holoviews/plotting/plotly/renderer.py
+++ b/holoviews/plotting/plotly/renderer.py
@@ -5,7 +5,8 @@ import json
 
 import param
 with param.logging_level('CRITICAL'):
-    from plotly.offline.offline import utils, get_plotlyjs, init_notebook_mode
+    from plotly import utils
+    from plotly.offline import get_plotlyjs, init_notebook_mode
     import plotly.graph_objs as go
 
 from ..renderer import Renderer, MIME_TYPES, HTML_TAGS

--- a/holoviews/plotting/plotly/util.py
+++ b/holoviews/plotting/plotly/util.py
@@ -79,6 +79,34 @@ _trace_to_subplot = {
     'scattermapbox': ['mapbox']
 }
 
+# trace types that support legends
+legend_trace_types = {
+    'scatter',
+    'bar',
+    'box',
+    'histogram',
+    'histogram2dcontour',
+    'contour',
+    'scatterternary',
+    'violin',
+    'waterfall',
+    'pie',
+    'scatter3d',
+    'scattergeo',
+    'scattergl',
+    'splom',
+    'pointcloud',
+    'scattermapbox',
+    'scattercarpet',
+    'contourcarpet',
+    'ohlc',
+    'candlestick',
+    'scatterpolar',
+    'scatterpolargl',
+    'barpolar',
+    'area',
+}
+
 # Aliases - map common style options to more common names
 
 STYLE_ALIASES = {'line_width': 'width', 'alpha': 'opacity',


### PR DESCRIPTION
Closes https://github.com/pyviz/holoviews/issues/3643

Two changes:
 - Change `plotly.offline.offline.utils` to `plotly.utils `
 - Only add legend options to traces that support them.  Plotly.js cleaned up the schema a bit to remove these entries from traces that don't use them, which resulted in some validation errors here.

These changes are backward compatible with plotly.py <3.8 so no need to change version constraints.