### PR TITLE
De-duplicating stream contents by value

### DIFF
--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -147,7 +147,7 @@ class Stream(param.Parameterized):
                 if len(values) > 1:
                     clashes.append((clash, values))
             if clashes:
-                msg = ', '.join(['%r has values %r' % (k,v) for k,v in clashes ])
+                msg = ', '.join(['%r has values %r' % (k, v) for k, v in clashes])
                 print('Parameter value clashes where %s' % msg )
 
         # Group subscribers by precedence while keeping the ordering

--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -135,7 +135,7 @@ class Stream(param.Parameterized):
         needs to be called once.
         """
         # Union of stream contents
-        items = [stream.contents.items() for stream in streams]
+        items = [stream.contents.items() for stream in set(streams)]
         union = [kv for kvs in items for kv in kvs]
         klist = [k for k, _ in union]
         key_clashes = set([k for k in klist if klist.count(k) > 1])

--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -138,9 +138,17 @@ class Stream(param.Parameterized):
         items = [stream.contents.items() for stream in streams]
         union = [kv for kvs in items for kv in kvs]
         klist = [k for k, _ in union]
-        clashes = set([k for k in klist if klist.count(k) > 1])
-        if clashes:
-            param.main.param.warning('Parameter name clashes for keys: %r' % clashes)
+        key_clashes = set([k for k in klist if klist.count(k) > 1])
+        if key_clashes:
+            clashes = []
+            dicts = [dict(kvs) for kvs in items]
+            for clash in key_clashes:
+                values = set(d[clash] for d in dicts if clash in d)
+                if len(values) > 1:
+                    clashes.append((clash, values))
+            if clashes:
+                msg = ', '.join(['%r has values %r' % (k,v) for k,v in clashes ])
+                print('Parameter value clashes where %s' % msg )
 
         # Group subscribers by precedence while keeping the ordering
         # within each group

--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -148,7 +148,7 @@ class Stream(param.Parameterized):
                     clashes.append((clash, values))
             if clashes:
                 msg = ', '.join(['%r has values %r' % (k, v) for k, v in clashes])
-                print('Parameter value clashes where %s' % msg )
+                print('Parameter value clashes where %s' % msg)
 
         # Group subscribers by precedence while keeping the ordering
         # within each group


### PR DESCRIPTION
If you change [this warning in streams.py](https://github.com/pyviz/holoviews/blob/master/holoviews/streams.py#L143) into a print (e.g `print('Parameter value clashes %s' % clashes)`) you will see that the warning is supposed to be issued for this example:

![image](https://user-images.githubusercontent.com/890576/56600373-24f8fd80-65be-11e9-856f-5cf3a82b1f6b.png)

### Code example

```python
import holoviews as hv
import dask.dataframe as dd
from holoviews.operation.datashader import rasterize

hv.extension('bokeh')
```

```python
path = '../../datashader/examples/data/nyc_taxi_wide.parq'
df = dd.read_parquet(path).persist()

points = hv.Points(df, ['dropoff_x', 'dropoff_y'], ['dropoff_hour','pickup_hour'])
options = hv.opts.Image( data_aspect=1, responsive=True, logz=True,
                      tools=['hover'], colorbar=True)
rasterize(points).options(options)
```

On current master, that warning doesn't appear:

![image](https://user-images.githubusercontent.com/890576/56600566-9fc21880-65be-11e9-8a2a-a5aef22bfa77.png)

The fact the warning is swallowed is one problem and the fact that two sets of `height`, `width` and `scale` are being issued on initialization might be another. That said, the height, width and scale values being sent are consistent duplicates. This PR now only issues a clash warning if the keys clash *and* the values are different. Although we should also avoid sending duplicate stream contents, I think such a change makes sense regardless.
