### PR TITLE
ensure underlying xarray dataset remain consistent with wrapping hv.Dataset

### DIFF
--- a/holoviews/core/data/xarray.py
+++ b/holoviews/core/data/xarray.py
@@ -455,6 +455,11 @@ class XArrayInterface(GridInterface):
                    if not data[d.name].data.shape)
         if dropped and not indexed:
             data = data.expand_dims(dropped)
+            # see https://github.com/pydata/xarray/issues/2891
+            # since we only exapanded on dimnesions of size 1
+            # we can monkeypatch the dataarray back to writeable.
+            for d in data.values():
+                d.data.flags.writeable = True 
 
         da = dask_array_module()
         if (indexed and len(data.data_vars) == 1 and

--- a/holoviews/core/data/xarray.py
+++ b/holoviews/core/data/xarray.py
@@ -450,11 +450,11 @@ class XArrayInterface(GridInterface):
 
         # Restore constant dimensions
         indexed = cls.indexed(dataset, selection)
-        dropped = {d.name: np.atleast_1d(data[d.name])
+        dropped = OrderedDict((d.name, np.atleast_1d(data[d.name]))
                    for d in dataset.kdims
-                   if not data[d.name].data.shape}
+                   if not data[d.name].data.shape)
         if dropped and not indexed:
-            data = data.assign_coords(**dropped)
+            data = data.expand_dims(dropped)
 
         da = dask_array_module()
         if (indexed and len(data.data_vars) == 1 and

--- a/holoviews/tests/core/data/testxarrayinterface.py
+++ b/holoviews/tests/core/data/testxarrayinterface.py
@@ -199,7 +199,16 @@ class XArrayInterfaceTests(GridInterfaceTests):
         expected = (np.datetime64(dt.datetime(2017, 12, 31, 12, 0)),
                     np.datetime64(dt.datetime(2018, 1, 10, 12, 0)))
         self.assertEqual(ds.range('x'), expected)
-        
+
+    def test_select_dropped_dimensions_restoration(self):
+        d = np.random.randn(3, 8)
+        da = xr.DataArray(d, name='stuff', dims=['chain', 'value'],
+            coords=dict(chain=range(d.shape[0]), value=range(d.shape[1])))
+        ds = Dataset(da)
+        t = ds.select(chain=0)
+        self.assertEqual(t.data.dims , dict(chain=1,value=8))
+        self.assertEqual(t.data.stuff.shape , (1,8))
+
     def test_dataset_array_init_hm(self):
         "Tests support for arrays (homogeneous)"
         raise SkipTest("Not supported")


### PR DESCRIPTION
holoviews `Dataset.select` uses `XArray`'s underlying `sel` method but this method
drops (squeezes) dimension of length 1. The use of `xarray.assign_coords` to restore the dropped
dimensions leaves the `xarray.Dataset` inconsistent with the wrapping` hv.Dataset`.

We use `xarray.expand_dims` to ensure consistency. 

You can see the problem with the following:
```
import numpy as np
import holoviews as hv
import xarray as xr
hv.extension('bokeh')

d = np.random.randn(3, 8)
X = xr.DataArray(
    d,  name='stuff', dims=['chain', 'value'], coords=dict(chain=range(d.shape[0]), value=range(d.shape[1])))
ds = hv.Dataset(X)
chain0 = ds.select(chain=0)
```
Although the XArray dataset dimensions have been restored:
`chain0.data.dims == dict(chain=1,value=8)`,
the underlying data array has still lost a dimension: `chain0.data.stuff.dims == ('value',), chain0.data.stuff.shape == (8,)`.

Making the following fail with "ValueError: 'chain' is not in list" (and to.curve, to.bars etc..)
```
chain0.to.table()
```
This pull request fixes this problem by simply using `xarray.expand_dims` instead
of `xarray.assign_coords`.
