### PR TITLE
Ensure that lists of Paths can be cast easily

### DIFF
--- a/holoviews/element/path.py
+++ b/holoviews/element/path.py
@@ -68,8 +68,12 @@ class Path(Geometry):
                 data = [np.column_stack((x, y[:, i])) for i in range(y.shape[1])]
         elif isinstance(data, list) and all(isinstance(path, Path) for path in data):
             # Allow unpacking of a list of Path elements
+            kdims = kdims or self.kdims
             paths = []
             for path in data:
+                if path.kdims != kdims:
+                    redim = {okd.name: nkd for okd, nkd in zip(path.kdims, kdims)}
+                    path = path.redim(**redim)
                 if path.interface.multi and isinstance(path.data, list):
                     paths += path.data
                 else:


### PR DESCRIPTION
We support a pattern like:

```python
hv.Path([hv.Bounds(...), hv.Bounds(...)])
```

This can be quite convenient but since I switched Bounds to use the dictionary data format I've found out that this pattern doesn't work when the columns in the data aren't named the same as the original object. This PR ensures that if the dimensions don't match they are replaced.

This cropped up when running EarthSim tests against 1.12.2a1