### PR TITLE
Revert stream value deduplication due to incomparable types

### DIFF
--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -140,15 +140,7 @@ class Stream(param.Parameterized):
         klist = [k for k, _ in union]
         key_clashes = set([k for k in klist if klist.count(k) > 1])
         if key_clashes:
-            clashes = []
-            dicts = [dict(kvs) for kvs in items]
-            for clash in key_clashes:
-                values = set(d[clash] for d in dicts if clash in d)
-                if len(values) > 1:
-                    clashes.append((clash, values))
-            if clashes:
-                msg = ', '.join(['%r has values %r' % (k, v) for k, v in clashes])
-                print('Parameter value clashes where %s' % msg)
+            print('Parameter name clashes for keys %r' % key_clashes)
 
         # Group subscribers by precedence while keeping the ordering
         # within each group


### PR DESCRIPTION
Addresses #3681 by largely reverting the changes in #3648. There is still an underlying issue however as taking `set` is not sufficient to remove clashes - there are still three `PlotSize` streams appearing in the example shown in  #3648.

For this reason, I am switching to using a print statement (which shows up in the web console) instead of logging to make sure this underlying issue isn't hidden again.