### PR TITLE
Reuse PlotSize stream if it exists

### DIFF
--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -488,8 +488,13 @@ class ElementPlot(BokehPlot, GenericElementPlot):
         if self.dynamic and aspect_props['match_aspect']:
             # Sync the plot size on dynamic plots to support accurate
             # scaling of dimension ranges
-            stream = PlotSize(subscribers=[self._update_size])
-            self.callbacks.append(PlotSizeCallback(self, [stream], None))
+            plot_size = [s for s in self.streams if isinstance(s, PlotSize)]
+            if plot_size:
+                stream = plot_size[0]
+                stream.add_subscriber(self._update_size)
+            else:
+                stream = PlotSize(subscribers=[self._update_size])
+                self.callbacks.append(PlotSizeCallback(self, [stream], None))
 
         plot_props = {
             'margin':        self.margin,


### PR DESCRIPTION
In order for data_aspect handling to work when a plot is updated dynamically a PlotSize stream is created to keep track of the screen size. However when the plot already has a PlotSize stream attached this is both superfluous and can cause parameter clashes in the Stream.trigger method. This PR simply reuses existing streams.