### PR TITLE
Fixed hv.help() for non-hv objects

### DIFF
--- a/holoviews/__init__.py
+++ b/holoviews/__init__.py
@@ -1,6 +1,6 @@
 
 from __future__ import print_function, absolute_import
-import os, pydoc, io
+import os, io
 
 import numpy as np # noqa (API import)
 import param
@@ -85,7 +85,8 @@ def help(obj, visualization=True, ansi=True, backend=None,
     if info:
         print((msg if visualization is False else '') + info)
     else:
+        import pydoc
         pydoc.help(obj)
 
 
-del absolute_import, io, np, os, print_function, pydoc, rcfile, warnings
+del absolute_import, io, np, os, print_function, rcfile, warnings


### PR DESCRIPTION
hv.help() was meant to fall back to pydoc for anything it doesn't understand, but that has apparently been broken for some time (see below).  Looks like it was because `pydoc` was deleted from the module namespace, presumably to clean up our API.  To achieve the same thing while also working properly, did a local import of `pydoc` just where it was needed.

![Screen Shot 2019-05-03 at 12 40 18 PM](https://user-images.githubusercontent.com/1695496/57155482-2afe9380-6da1-11e9-9b37-599f1bdbc769.png)
