### PR TITLE
Clarify max frames warning in notebooks

### DIFF
--- a/holoviews/ipython/display_hooks.py
+++ b/holoviews/ipython/display_hooks.py
@@ -35,10 +35,12 @@ ABBREVIATE_TRACEBACKS = True
 
 
 def max_frame_warning(max_frames):
-    sys.stderr.write("Skipping regular visual display to avoid "
-                     "lengthy animation render times\n"
-                     "[Total item frames exceeds max_frames on OutputSettings (%d)]"
-                     % max_frames)
+    sys.stderr.write(
+        "You are trying to display over {max_frames} frames.\n"
+        "To avoid unexpected lengthy rendering times this will be skipped.\n"
+        "This can be changed using the following notebook magic:\n"
+        "%output max_frames=<insert number>".format(max_frames=max_frames)
+    )
 
 def process_object(obj):
     "Hook to process the object currently being displayed."

--- a/holoviews/ipython/display_hooks.py
+++ b/holoviews/ipython/display_hooks.py
@@ -39,7 +39,7 @@ def max_frame_warning(max_frames):
         "You are trying to display over {max_frames} frames.\n"
         "To avoid unexpected lengthy rendering times this will be skipped.\n"
         "This can be changed using the following notebook magic:\n"
-        "%output max_frames=<insert number>".format(max_frames=max_frames)
+        "hv.output(max_frames=<insert number>)".format(max_frames=max_frames)
     )
 
 def process_object(obj):


### PR DESCRIPTION
Resolves https://github.com/pyviz/holoviews/issues/2993

This pull request clarifies the wording of a warning message that is shown when a user attempts to display a plot with a big number of frames in a notebook.

Please check spelling and grammar since English is not my first language. 