### PR TITLE
Ensure Param streams handle subobject dependencies

### DIFF
--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -200,7 +200,7 @@ class Stream(param.Parameterized):
                         'Ensure that the supplied streams only specify '
                         'each parameter once, otherwise multiple '
                         'events will be triggered when the parameter '
-                        'changes.' % (sorted(overlap), pname))
+                        'changes.' % (sorted([p.name for p in overlap]), pname))
                 parameterizeds[pid] |= set(s.parameters)
             valid.append(s)
         return valid, invalid
@@ -665,10 +665,11 @@ class Params(Stream):
         return streams
 
     def _validate_rename(self, mapping):
+        pnames = [p.name for p in self.parameters]
         for k, v in mapping.items():
-            if k not in self.parameters:
+            if k not in pnames:
                 raise KeyError('Cannot rename %r as it is not a stream parameter' % k)
-            if k != v and v in self.parameters:
+            if k != v and v in pnames:
                 raise KeyError('Cannot rename to %r as it clashes with a '
                                'stream parameter of the same name' % v)
         return mapping
@@ -703,8 +704,7 @@ class Params(Stream):
 
     @property
     def contents(self):
-        filtered = {k: v for k, v in self.parameterized.get_param_values()
-                    if k in self.parameters}
+        filtered = {p.name: getattr(p.owner, p.name) for p in self.parameters}
         return {self._rename.get(k, k): v for (k, v) in filtered.items()
                 if self._rename.get(k, True) is not None}
 

--- a/holoviews/tests/core/testapply.py
+++ b/holoviews/tests/core/testapply.py
@@ -70,7 +70,7 @@ class TestApplyElement(ComparisonTestCase):
         stream = applied.streams[0]
         self.assertIsInstance(stream, Params)
         self.assertEqual(stream.parameterized, pinst)
-        self.assertEqual(stream.parameters, ['label'])
+        self.assertEqual(stream.parameters, [pinst.param.label])
 
         # Check results
         self.assertEqual(applied[()], self.element.relabel('Test'))
@@ -86,7 +86,7 @@ class TestApplyElement(ComparisonTestCase):
         stream = applied.streams[0]
         self.assertIsInstance(stream, Params)
         self.assertEqual(stream.parameterized, pinst)
-        self.assertEqual(stream.parameters, ['label'])
+        self.assertEqual(stream.parameters, [pinst.param.label])
 
         # Check results
         self.assertEqual(applied[()], self.element.relabel('Test'))
@@ -102,7 +102,7 @@ class TestApplyElement(ComparisonTestCase):
         stream = applied.streams[0]
         self.assertIsInstance(stream, ParamMethod)
         self.assertEqual(stream.parameterized, pinst)
-        self.assertEqual(stream.parameters, ['label'])
+        self.assertEqual(stream.parameters, [pinst.param.label])
 
         # Check results
         self.assertEqual(applied[()], self.element.relabel('Test'))
@@ -118,7 +118,7 @@ class TestApplyElement(ComparisonTestCase):
         stream = applied.streams[0]
         self.assertIsInstance(stream, ParamMethod)
         self.assertEqual(stream.parameterized, pinst)
-        self.assertEqual(stream.parameters, ['label'])
+        self.assertEqual(stream.parameters, [pinst.param.label])
 
         # Check result
         self.assertEqual(applied[()], self.element.relabel('Test!'))
@@ -180,7 +180,7 @@ class TestApplyDynamicMap(ComparisonTestCase):
         stream = applied.streams[0]
         self.assertIsInstance(stream, Params)
         self.assertEqual(stream.parameterized, pinst)
-        self.assertEqual(stream.parameters, ['label'])
+        self.assertEqual(stream.parameters, [pinst.param.label])
 
         # Check results
         self.assertEqual(applied[1], self.dmap[1].relabel('Test'))
@@ -203,7 +203,7 @@ class TestApplyDynamicMap(ComparisonTestCase):
         stream = applied.streams[0]
         self.assertIsInstance(stream, ParamMethod)
         self.assertEqual(stream.parameterized, pinst)
-        self.assertEqual(stream.parameters, ['label'])
+        self.assertEqual(stream.parameters, [pinst.param.label])
 
         # Check results
         self.assertEqual(applied[1], self.dmap[1].relabel('Test'))
@@ -219,7 +219,7 @@ class TestApplyDynamicMap(ComparisonTestCase):
         stream = applied.streams[0]
         self.assertIsInstance(stream, ParamMethod)
         self.assertEqual(stream.parameterized, pinst)
-        self.assertEqual(stream.parameters, ['label'])
+        self.assertEqual(stream.parameters, [pinst.param.label])
 
         # Check result
         self.assertEqual(applied[1], self.dmap[1].relabel('Test!'))

--- a/holoviews/tests/core/testdynamic.py
+++ b/holoviews/tests/core/testdynamic.py
@@ -388,6 +388,12 @@ class DynamicMapOptionsTests(CustomBackendTestCase):
         opts = Store.lookup_options('backend_1', dmap[0], 'plot')
         self.assertEqual(opts.options, {'plot_opt1': 'red'})
 
+    def test_dynamic_posargs_resolved(self):
+        def f(s):
+            return Curve([1, 2, s])
+        dmap = DynamicMap(f, kdims=['scale']).opts(color='red')
+        self.asserrtdmap[2]
+
     def test_dynamic_opts_link_inputs(self):
         stream = LinkedStream()
         inputs = [DynamicMap(lambda: None, streams=[stream])]

--- a/holoviews/tests/core/testdynamic.py
+++ b/holoviews/tests/core/testdynamic.py
@@ -388,12 +388,6 @@ class DynamicMapOptionsTests(CustomBackendTestCase):
         opts = Store.lookup_options('backend_1', dmap[0], 'plot')
         self.assertEqual(opts.options, {'plot_opt1': 'red'})
 
-    def test_dynamic_posargs_resolved(self):
-        def f(s):
-            return Curve([1, 2, s])
-        dmap = DynamicMap(f, kdims=['scale']).opts(color='red')
-        self.asserrtdmap[2]
-
     def test_dynamic_opts_link_inputs(self):
         stream = LinkedStream()
         inputs = [DynamicMap(lambda: None, streams=[stream])]

--- a/holoviews/tests/core/testoperation.py
+++ b/holoviews/tests/core/testoperation.py
@@ -43,7 +43,7 @@ class TestOperationBroadcast(ComparisonTestCase):
         applied = TestOperation(curve, label=inst.param.label)
         self.assertEqual(len(applied.streams), 1)
         self.assertIsInstance(applied.streams[0], Params)
-        self.assertEqual(applied.streams[0].parameters, ['label'])
+        self.assertEqual(applied.streams[0].parameters, [pinst.param.label])
         self.assertEqual(applied[()], curve.relabel('Test'))
 
     def test_element_dynamic_with_param_method(self):
@@ -52,7 +52,7 @@ class TestOperationBroadcast(ComparisonTestCase):
         applied = TestOperation(curve, label=inst.dynamic_label)
         self.assertEqual(len(applied.streams), 1)
         self.assertIsInstance(applied.streams[0], Params)
-        self.assertEqual(applied.streams[0].parameters, ['label'])
+        self.assertEqual(applied.streams[0].parameters, [inst.param.label])
         self.assertEqual(applied[()], curve.relabel('Test!'))
         inst.label = 'New label'
         self.assertEqual(applied[()], curve.relabel('New label!'))

--- a/holoviews/tests/core/testoperation.py
+++ b/holoviews/tests/core/testoperation.py
@@ -43,7 +43,7 @@ class TestOperationBroadcast(ComparisonTestCase):
         applied = TestOperation(curve, label=inst.param.label)
         self.assertEqual(len(applied.streams), 1)
         self.assertIsInstance(applied.streams[0], Params)
-        self.assertEqual(applied.streams[0].parameters, [pinst.param.label])
+        self.assertEqual(applied.streams[0].parameters, [inst.param.label])
         self.assertEqual(applied[()], curve.relabel('Test'))
 
     def test_element_dynamic_with_param_method(self):

--- a/holoviews/tests/teststreams.py
+++ b/holoviews/tests/teststreams.py
@@ -198,7 +198,8 @@ class TestParamsStream(LoggingComparisonTestCase):
 
     def test_param_stream_class(self):
         stream = Params(self.inner)
-        self.assertEqual(set(stream.parameters), {'x', 'y'})
+        self.assertEqual(set(stream.parameters), {self.inner.param.x,
+                                                  self.inner.param.y})
         self.assertEqual(stream.contents, {'x': 0, 'y': 0})
 
         values = []
@@ -212,7 +213,7 @@ class TestParamsStream(LoggingComparisonTestCase):
     def test_param_stream_instance(self):
         inner = self.inner(x=2)
         stream = Params(inner)
-        self.assertEqual(set(stream.parameters), {'x', 'y'})
+        self.assertEqual(set(stream.parameters), {inner.param.x, inner.param.y})
         self.assertEqual(stream.contents, {'x': 2, 'y': 0})
 
         values = []
@@ -249,9 +250,9 @@ class TestParamsStream(LoggingComparisonTestCase):
         xparam, yparam = valid
 
         self.assertIs(xparam.parameterized, inner)
-        self.assertEqual(xparam.parameters, ['x'])
+        self.assertEqual(xparam.parameters, [inner.param.x])
         self.assertIs(yparam.parameterized, inner)
-        self.assertEqual(yparam.parameters, ['y'])
+        self.assertEqual(yparam.parameters, [inner.param.y])
 
     def test_param_parameter_instance_overlapping_parameters(self):
         inner = self.inner()
@@ -261,7 +262,7 @@ class TestParamsStream(LoggingComparisonTestCase):
     def test_param_stream_parameter_override(self):
         inner = self.inner(x=2)
         stream = Params(inner, parameters=['x'])
-        self.assertEqual(stream.parameters, ['x'])
+        self.assertEqual(stream.parameters, [inner.param.x])
         self.assertEqual(stream.contents, {'x': 2})
 
         values = []
@@ -275,7 +276,7 @@ class TestParamsStream(LoggingComparisonTestCase):
     def test_param_stream_rename(self):
         inner = self.inner(x=2)
         stream = Params(inner, rename={'x': 'X', 'y': 'Y'})
-        self.assertEqual(set(stream.parameters), {'x', 'y'})
+        self.assertEqual(set(stream.parameters), {inner.param.x, inner.param.y})
         self.assertEqual(stream.contents, {'X': 2, 'Y': 0})
 
         values = []
@@ -289,7 +290,7 @@ class TestParamsStream(LoggingComparisonTestCase):
     def test_param_stream_action(self):
         inner = self.inner_action()
         stream = Params(inner, ['action'])
-        self.assertEqual(set(stream.parameters), {'action'})
+        self.assertEqual(set(stream.parameters), {inner.param.action})
 
         values = []
         def subscriber(**kwargs):
@@ -304,7 +305,7 @@ class TestParamsStream(LoggingComparisonTestCase):
     def test_param_stream_memoization(self):
         inner = self.inner_action()
         stream = Params(inner, ['action', 'x'])
-        self.assertEqual(set(stream.parameters), {'action', 'x'})
+        self.assertEqual(set(stream.parameters), {inner.param.action, inner.param.x})
 
         values = []
         def subscriber(**kwargs):
@@ -358,7 +359,7 @@ class TestParamMethodStream(ComparisonTestCase):
     def test_param_method_depends(self):
         inner = self.inner()
         stream = ParamMethod(inner.method)
-        self.assertEqual(set(stream.parameters), {'x'})
+        self.assertEqual(set(stream.parameters), {inner.param.x})
         self.assertEqual(stream.contents, {})
 
         values = []
@@ -373,7 +374,10 @@ class TestParamMethodStream(ComparisonTestCase):
     def test_param_method_depends_no_deps(self):
         inner = self.inner()
         stream = ParamMethod(inner.method_no_deps)
-        self.assertEqual(set(stream.parameters), {'x', 'y', 'action', 'name', 'count'})
+        self.assertEqual(set(stream.parameters), {
+            inner.param.x, inner.param.y, inner.param.action,
+            inner.param.name, inner.param.count
+        })
         self.assertEqual(stream.contents, {})
 
         values = []
@@ -405,7 +409,7 @@ class TestParamMethodStream(ComparisonTestCase):
     def test_param_method_depends_trigger_no_memoization(self):
         inner = self.inner()
         stream = ParamMethod(inner.method)
-        self.assertEqual(set(stream.parameters), {'x'})
+        self.assertEqual(set(stream.parameters), {inner.param.x})
         self.assertEqual(stream.contents, {})
 
         values = []
@@ -421,7 +425,7 @@ class TestParamMethodStream(ComparisonTestCase):
         inner = self.inner()
         dmap = DynamicMap(inner.method)
         stream = dmap.streams[0]
-        self.assertEqual(set(stream.parameters), {'x'})
+        self.assertEqual(set(stream.parameters), {inner.param.x})
         self.assertEqual(stream.contents, {})
 
         dmap[()]
@@ -438,7 +442,7 @@ class TestParamMethodStream(ComparisonTestCase):
         dmap = DynamicMap(inner.action_method)
         self.assertEqual(len(dmap.streams), 1)
         stream = dmap.streams[0]
-        self.assertEqual(set(stream.parameters), {'action'})
+        self.assertEqual(set(stream.parameters), {inner.param.action})
         self.assertIsInstance(stream, ParamMethod)
         self.assertEqual(stream.contents, {})
 
@@ -457,7 +461,7 @@ class TestParamMethodStream(ComparisonTestCase):
         dmap = DynamicMap(inner.action_number_method)
         self.assertEqual(len(dmap.streams), 1)
         stream = dmap.streams[0]
-        self.assertEqual(set(stream.parameters), {'action', 'x'})
+        self.assertEqual(set(stream.parameters), {inner.param.action, inner.param.x})
         self.assertIsInstance(stream, ParamMethod)
         self.assertEqual(stream.contents, {})
 
@@ -483,7 +487,7 @@ class TestParamMethodStream(ComparisonTestCase):
         op_dmap = Dynamic(dmap, operation=inner.op_method)
         self.assertEqual(len(op_dmap.streams), 1)
         stream = op_dmap.streams[0]
-        self.assertEqual(set(stream.parameters), {'y'})
+        self.assertEqual(set(stream.parameters), {inner.param.y})
         self.assertIsInstance(stream, ParamMethod)
         self.assertEqual(stream.contents, {})
 
@@ -501,7 +505,7 @@ class TestParamMethodStream(ComparisonTestCase):
         self.assertEqual(values_y, [{}])
 
 
-        
+
 class TestSubscribers(ComparisonTestCase):
 
     def test_exception_subscriber(self):


### PR DESCRIPTION
The Params and ParamMethod streams only handled dependencies on the main parameterized object but did not handle subobject dependencies. This PR ensures both are handled.