### PR TITLE
Fix setting edge colors for Chord graphs using an explicit mapping

### DIFF
--- a/holoviews/plotting/mpl/element.py
+++ b/holoviews/plotting/mpl/element.py
@@ -907,7 +907,13 @@ class ColorbarPlot(ElementPlot):
 
         if not isinstance(cmap, mpl_colors.Colormap):
             if isinstance(cmap, dict):
-                factors = util.unique_array(values)
+                # The palette needs to correspond to the map's limits (vmin/vmax). So use the same
+                # factors as in the map's clim computation above.
+                range_key = dim_range_key(vdim)
+                if range_key in ranges and 'factors' in ranges[range_key]:
+                    factors = ranges[range_key]['factors']
+                else:
+                    factors = util.unique_array(values)
                 palette = [cmap.get(f, colors.get('NaN', {'color': self._default_nan})['color'])
                            for f in factors]
             else:


### PR DESCRIPTION
and normalization (which is turned on by default).

Details:
The color map's vmin/vmax was computed based on factors of the whole range
whereas the palette only used the factors from the actually used values.

When using color normalization this lead to:
-- LineCollection normalizing via vmin/vmax computed above, reflecting the
   whole range.
-- ListedColormap is transforming the normalized color values provided by the
   LineCollection using its own size (N). However that size N was based on the
   actually used values and hence too small.