### PR TITLE
datetime handling for spikes

### DIFF
--- a/holoviews/plotting/mpl/chart.py
+++ b/holoviews/plotting/mpl/chart.py
@@ -14,7 +14,7 @@ from ...core.dimension import Dimension, dimension_name
 from ...core.options import Store, abbreviated_exception
 from ...core.util import (
     OrderedDict, match_spec, unique_iterator, basestring, max_range,
-    isfinite, datetime_types, dt_to_int, dt64_to_dt, search_indices,
+    isfinite, dt_to_int, dt64_to_dt, search_indices,
     unique_array, isscalar, isdatetime
 )
 from ...element import Raster, HeatMap
@@ -1192,7 +1192,7 @@ class SpikesPlot(PathPlot, ColorbarPlot):
             for i, vs in enumerate((xs, ys)):
                 vs = np.array(vs)
                 if isdatetime(vs):
-                    generic_dt_format = dt_format = Dimension.type_formatters.get(
+                    dt_format = Dimension.type_formatters.get(
                         type(vs[0]),
                         Dimension.type_formatters[np.datetime64]
                     )


### PR DESCRIPTION
The previous implementation of get_data for Spikes in the matplotlib backend used the `element.array()` method, which already coerces datetime values to int in case of mixed data types. I fixed that and updated the datetime handling using recently added utils. 

The following now works, whereas before it didn't:

```
import pandas as pd
import numpy as np
import holoviews as hv
hv.extension('matplotlib')

e = hv.Spikes((pd.date_range('2100-1-1', '2100-10-10', periods=20), np.random.rand(20)), 'Date', 'c')
e.opts(xrotation=45)
```

<img width="365" alt="Screen Shot 2019-05-27 at 3 20 57 PM" src="https://user-images.githubusercontent.com/38992106/58436378-13aa8180-8093-11e9-8416-0b3b57399d0b.png">
