### PR TITLE
remove frameon from default mpl styles

### DIFF
--- a/holoviews/plotting/mpl/default.mplstyle
+++ b/holoviews/plotting/mpl/default.mplstyle
@@ -23,7 +23,6 @@ grid.color: black
 grid.linestyle: :
 
 legend.loc: upper right
-legend.frameon: True
 legend.fontsize: small
 legend.fancybox: True
 

--- a/holoviews/plotting/mpl/default1.5.mplstyle
+++ b/holoviews/plotting/mpl/default1.5.mplstyle
@@ -23,7 +23,6 @@ grid.color: black
 grid.linestyle: :
 
 legend.loc: upper right
-legend.frameon: True
 legend.fontsize: small
 legend.fancybox: True
 


### PR DESCRIPTION
The frameon rcparam is marked for deprecation in MPL 3.3, see https://github.com/matplotlib/matplotlib/pull/11692