### PR TITLE
Updated definition of box plot whiskers to match convention for Bokeh plots.

### DIFF
--- a/holoviews/plotting/bokeh/stats.py
+++ b/holoviews/plotting/bokeh/stats.py
@@ -137,8 +137,8 @@ class BoxWhiskerPlot(CompositeElementPlot, ColorbarPlot, LegendPlot):
             q1, q2, q3 = (np.percentile(vals, q=q)
                           for q in range(25, 100, 25))
             iqr = q3 - q1
-            upper = min(q3 + 1.5 * iqr, vals.max())
-            lower = max(q1 - 1.5 * iqr, vals.min())
+            upper = vals[vals <= top + 1.5*iqr].max()
+            lower = vals[vals >= bottom - 1.5*iqr].min()
         else:
             q1, q2, q3 = 0, 0, 0
             upper, lower = 0, 0

--- a/holoviews/plotting/bokeh/stats.py
+++ b/holoviews/plotting/bokeh/stats.py
@@ -137,8 +137,8 @@ class BoxWhiskerPlot(CompositeElementPlot, ColorbarPlot, LegendPlot):
             q1, q2, q3 = (np.percentile(vals, q=q)
                           for q in range(25, 100, 25))
             iqr = q3 - q1
-            upper = vals[vals <= top + 1.5*iqr].max()
-            lower = vals[vals >= bottom - 1.5*iqr].min()
+            upper = vals[vals <= q3 + 1.5*iqr].max()
+            lower = vals[vals >= q1 - 1.5*iqr].min()
         else:
             q1, q2, q3 = 0, 0, 0
             upper, lower = 0, 0


### PR DESCRIPTION
In #1926, I suggested using a definition of the whiskers length in box plots as follows:

The top whisker extends 1.5 times the IQR beyond the top of the box or to the maximal data point, whichever is smaller. An analogous definition holds for the bottom whisker. This is how the whisker is defined in some places, e.g., [here](https://www.stat.berkeley.edu/~brill/Papers/EDASage.pdf).

A vastly more widely adapted version uses this definition:
The top whisker extends to the maximum of the set of data points that are less than 1.5 times the IQR beyond the top of the box, with an analogous definition for the lower whisker.

This is what the [HoloViews docs say](http://holoviews.org/reference/elements/bokeh/BoxWhisker.html). This PR brings the Bokeh rendering of box and whisker plots.

My apologies for the confusion with #1926.