### PR TITLE
Fix GridSpace and GridMatrix sort=False

### DIFF
--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -1903,8 +1903,8 @@ class GridSpace(UniformNdMapping):
         keys = super(GridSpace, self).keys()
         if self.ndims == 1 or not full_grid:
             return keys
-        dim1_keys = list(dict.fromkeys(k[0] for k in keys))
-        dim2_keys = list(dict.fromkeys(k[1] for k in keys))
+        dim1_keys = list(OrderedDict.fromkeys(k[0] for k in keys))
+        dim2_keys = list(OrderedDict.fromkeys(k[1] for k in keys))
         return [(d1, d2) for d1 in dim1_keys for d2 in dim2_keys]
 
 

--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -1903,8 +1903,8 @@ class GridSpace(UniformNdMapping):
         keys = super(GridSpace, self).keys()
         if self.ndims == 1 or not full_grid:
             return keys
-        dim1_keys = sorted(set(k[0] for k in keys))
-        dim2_keys = sorted(set(k[1] for k in keys))
+        dim1_keys = list(dict.fromkeys(k[0] for k in keys))
+        dim2_keys = list(dict.fromkeys(k[1] for k in keys))
         return [(d1, d2) for d1 in dim1_keys for d2 in dim2_keys]
 
 

--- a/holoviews/plotting/mpl/raster.py
+++ b/holoviews/plotting/mpl/raster.py
@@ -233,12 +233,13 @@ class RasterGridPlot(GridPlot, OverlayPlot):
         self.overlaid = False
         self.hmap = layout
         if layout.ndims > 1:
-            xkeys, ykeys = zip(*layout.data.keys())
+            xkeys, ykeys = zip(*layout.keys())
         else:
             xkeys = layout.keys()
             ykeys = [None]
-        self._xkeys = sorted(set(xkeys))
-        self._ykeys = sorted(set(ykeys))
+        self._xkeys = list(dict.fromkeys(xkeys))
+        self._ykeys = list(dict.fromkeys(ykeys))
+        
         self._xticks, self._yticks = [], []
         self.rows, self.cols = layout.shape
         self.fig_inches = self._get_size()


### PR DESCRIPTION
Fixes #3462

Previously, `sorted(set(...))` implicitly sorted grid keys, now passing sort=False has the intended effect:

```
import numpy as np
import holoviews as hv
hv.extension('matplotlib')

data = hv.Image(np.random.rand(10,10))
imgs = [
    (('C', 'dummy'), data),
    (('D', 'dummy'), data),
    (('A', 'dummy'), data),
    (('B', 'dummy'), data)
]
hv.GridSpace(imgs, sort=False, kdims=['dim1','dim2'])
```

<img width="629" alt="Screen Shot 2019-06-12 at 12 29 10 PM" src="https://user-images.githubusercontent.com/38992106/59369120-b4dd3d00-8d0d-11e9-8750-cd175794e424.png">

<img width="380" alt="Screen Shot 2019-06-12 at 12 29 31 PM" src="https://user-images.githubusercontent.com/38992106/59369141-be66a500-8d0d-11e9-9a27-013be1313940.png">

#3770 is vaguely related (this PR highlights some code duplication) in the (non-) sorting of dimension values.