### PR TITLE
add package dependencies to nytaxi example

### DIFF
--- a/examples/gallery/apps/bokeh/nytaxi_hover.py
+++ b/examples/gallery/apps/bokeh/nytaxi_hover.py
@@ -9,7 +9,7 @@ you can obtain by downloading the file from AWS:
 
 Place this parquet in a data/ subfolder and install the python dependencies, e.g.
 
-  conda install dask xyarray fastparquet python-snappy
+  conda install datashader fastparquet python-snappy
 
 You can now run this app with:
 

--- a/examples/gallery/apps/bokeh/nytaxi_hover.py
+++ b/examples/gallery/apps/bokeh/nytaxi_hover.py
@@ -7,8 +7,11 @@ you can obtain by downloading the file from AWS:
 
   https://s3.amazonaws.com/datashader-data/nyc_taxi_wide.parq
 
-Once this parquet is placed in a data/ subfolder, you can run this app
-with:
+Place this parquet in a data/ subfolder and install the python dependencies, e.g.
+
+  conda install dask xyarray fastparquet python-snappy
+
+You can now run this app with:
 
   bokeh serve --show nytaxi_hover.py
 


### PR DESCRIPTION
when running the app, python will complain about missing direct imports
(dask, xarray, datashader), but the other missing dependencies (fastparquet
and python-snappy) are more difficult to track down, since the `bokeh serve`
command will simply show a white page with no exception on the
python console.

The dependencies listed in the PR are the ones needed in addition if
holoviews was installed via the recommended way:

 conda install -c pyviz holoviews bokeh