### PR TITLE
Enable cmap option in matplotlib HexTiles

### DIFF
--- a/holoviews/plotting/mpl/hex_tiles.py
+++ b/holoviews/plotting/mpl/hex_tiles.py
@@ -29,7 +29,7 @@ class HexTilesPlot(ColorbarPlot):
       The display threshold before a bin is shown, by default bins with
       a count of less than 1 are hidden.""")
 
-    style_opts = ['edgecolors', 'alpha', 'linewidths', 'marginals']
+    style_opts = ['cmap', 'edgecolors', 'alpha', 'linewidths', 'marginals']
 
     _nonvectorized_styles = style_opts
 


### PR DESCRIPTION
Now, the following is possible, whereas before it wasn't:

```
import holoviews as hv
hv.extension('matplotlib')
import numpy as np
hv.HexTiles(np.random.randn(10000,2)).opts(cmap='Greens', colorbar=True)
```

If there is any testing being done on cmap and the like, I'd be happy to implement a test if you'd like.