### PR TITLE
Add MPL 3.1 deprecations to rcparam context manager

### DIFF
--- a/holoviews/plotting/mpl/plot.py
+++ b/holoviews/plotting/mpl/plot.py
@@ -27,7 +27,13 @@ def _rc_context(rcparams):
     """
     Context manager that temporarily overrides the pyplot rcParams.
     """
-    deprecated = ['text.latex.unicode', 'examples.directory']
+    deprecated = [
+        'text.latex.unicode',
+        'examples.directory',
+        'savefig.frameon', # deprecated in MPL 3.1, to be removed in 3.3
+        'verbose.level', # deprecated in MPL 3.1, to be removed in 3.3
+        'verbose.fileo', # deprecated in MPL 3.1, to be removed in 3.3
+    ]
     old_rcparams = {k: mpl.rcParams[k] for k in mpl.rcParams.keys()
                     if mpl_version < '3.0' or k not in deprecated}
     mpl.rcParams.clear()


### PR DESCRIPTION
Completes #3745 and thereby fixes #3766
Source: https://matplotlib.org/3.1.0/api/api_changes.html

This confused me for a bit, but it turned out that the deprecated arguments were simply carried over from `matplotlib.rcParams` where they then threw the warnings.

