### PR TITLE
Fixed legends for PathPlot

### DIFF
--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -1030,12 +1030,11 @@ class ElementPlot(BokehPlot, GenericElementPlot):
                     else:
                         factors = util.unique_array(val)
                     kwargs['factors'] = factors
-                    if factors is not None and getattr(self, 'show_legend', False):
-                        new_style['legend'] = key
                 cmapper = self._get_colormapper(v, element, ranges,
                                                 dict(style), name=k+'_color_mapper',
                                                 group=group, **kwargs)
-                if isinstance(cmapper, CategoricalColorMapper) and val.dtype.kind in 'ifMu':
+                categorical = isinstance(cmapper, CategoricalColorMapper)
+                if categorical and val.dtype.kind in 'ifMu':
                     if v.dimension in element:
                         formatter = element.get_dimension(v.dimension).pprint_value
                     else:
@@ -1044,6 +1043,8 @@ class ElementPlot(BokehPlot, GenericElementPlot):
                     data[k+'_str__'] = [formatter(d) for d in val]
                 else:
                     field = k
+                if categorical and getattr(self, 'show_legend', False):
+                    new_style['legend'] = field
                 key = {'field': field, 'transform': cmapper}
             new_style[k] = key
 

--- a/holoviews/plotting/bokeh/path.py
+++ b/holoviews/plotting/bokeh/path.py
@@ -15,7 +15,7 @@ from .styles import (expand_batched_style, line_properties, fill_properties,
 from .util import bokeh_version, multi_polygons_data
 
 
-class PathPlot(ColorbarPlot):
+class PathPlot(LegendPlot, ColorbarPlot):
 
     show_legend = param.Boolean(default=False, doc="""
         Whether to show legend for the plot.""")
@@ -143,7 +143,7 @@ class PathPlot(ColorbarPlot):
         return data, elmapping, style
 
 
-class ContourPlot(LegendPlot, PathPlot):
+class ContourPlot(PathPlot):
 
     show_legend = param.Boolean(default=False, doc="""
         Whether to show legend for the plot.""")

--- a/holoviews/tests/plotting/bokeh/testpathplot.py
+++ b/holoviews/tests/plotting/bokeh/testpathplot.py
@@ -168,6 +168,23 @@ class TestPathPlot(TestBokehPlot):
         self.assertEqual(source.data['ys'], [np.array([4, 3]), np.array([3, 2]), np.array([2, 1])])
         self.assertEqual(source.data['line_width'], np.array([1, 7, 3]))
 
+    def test_path_continuously_varying_color_legend(self):
+        data = {
+            "x": [1,2,3,4,5,6,7,8,9],
+            "y":   [1,2,3,4,5,6,7,8,9],
+            "cat": [0,1,2,0,1,2,0,1,2]
+        }
+
+        colors = ["#FF0000", "#00FF00", "#0000FF"]
+        levels=[0,1,2,3]
+
+        path = Path(data, vdims="cat").opts(color="cat", cmap=dict(zip(levels, colors)), line_width=4, show_legend=True)
+        plot = bokeh_renderer.get_plot(path)
+        item = plot.state.legend[0].items[0]
+        self.assertEqual(item.label, 'color_str__')
+        self.assertEqual(item.renderers, [plot.handles['glyph_renderer']])
+
+        
 
 class TestPolygonPlot(TestBokehPlot):
 


### PR DESCRIPTION
Ensures that this generates a legend:

```python
data = {"x": [1,2,3,4,5,6,7,8,9],
"y":   [1,2,3,4,5,6,7,8,9],
"cat": [0,1,2,0,1,2,0,1,2]}

colors = ["#FF0000", "#00FF00", "#0000FF"]
levels=[0,1,2,3]

hv.Path(data, vdims="cat").opts(color="cat", cmap=dict(zip(levels, colors)), line_width=4, show_legend=True)
```

![bokeh_plot - 2019-07-09T144905 785](https://user-images.githubusercontent.com/1550771/60889167-b5a7b700-a258-11e9-9d1c-195ee119b5a3.png)

- [x] Add unit test
