### PR TITLE
Make matplotlib Bars respect lower ylim if logy=True

### DIFF
--- a/holoviews/plotting/mpl/chart.py
+++ b/holoviews/plotting/mpl/chart.py
@@ -945,7 +945,8 @@ class BarPlot(LegendPlot):
             return 0, 0, ngroups, np.NaN
         else:
             vrange = ranges[vdim]['combined']
-            return 0, np.nanmin([vrange[0], 0]), ngroups, vrange[1]
+            lower_limit = vrange[0] if self.logy else np.nanmin([vrange[0], 0])
+            return 0, lower_limit, ngroups, vrange[1]
 
 
     @mpl_rc_context


### PR DESCRIPTION
Code:
```
import holoviews as hv
import pandas as pd

hv.extension('matplotlib')

df = pd.DataFrame(dict(u=['A', 'B'], y=[10,3]))
l = hv.Bars(df, ['u'], 'y')
l = l.opts(
    logy=True,
)

l.redim.range(y=(0.0001, 10))
```

Before:

`WARNING:param.BarPlot01437: Logarithmic axis range encountered value less than or equal to zero, please supply explicit lower-bound to override default of 0.100.`

![Screen Shot 2019-07-09 at 7 24 22 PM](https://user-images.githubusercontent.com/38992106/60929393-2e216e80-a27f-11e9-98e4-1010098f079e.png)

After:

![Screen Shot 2019-07-09 at 7 23 53 PM](https://user-images.githubusercontent.com/38992106/60929399-34afe600-a27f-11e9-8dfd-814ecf475d61.png)