### PR TITLE
Fixed handling of data_aspect

### DIFF
--- a/examples/user_guide/Plotting_with_Bokeh.ipynb
+++ b/examples/user_guide/Plotting_with_Bokeh.ipynb
@@ -279,7 +279,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "img.opts(data_aspect=10, responsive=True, title='scale both')"
+    "img.opts(data_aspect=0.5, responsive=True, title='scale both')"
    ]
   },
   {

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -779,7 +779,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
             xspan = r-l if util.is_number(l) and util.is_number(r) else None
             yspan = t-b if util.is_number(b) and util.is_number(t) else None
 
-            if self.drawn or self.aspect != 'equal':
+            if self.drawn or (self.aspect != 'equal' and fixed_width and fixed_height):
                 # After initial draw or if aspect is explicit
                 # adjust range to match the plot dimension aspect
                 ratio = self.data_aspect or 1
@@ -814,11 +814,11 @@ class ElementPlot(BokehPlot, GenericElementPlot):
 
                 if fixed_height:
                     plot.frame_height = height
-                    plot.frame_width = int(height*aspect)
+                    plot.frame_width = int(height/aspect)
                     plot.plot_width, plot.plot_height = None, None
                 elif fixed_width:
                     plot.frame_width = width
-                    plot.frame_height = int(width/aspect)
+                    plot.frame_height = int(width*aspect)
                     plot.plot_width, plot.plot_height = None, None
                 else:
                     plot.aspect_ratio = 1./aspect
@@ -906,7 +906,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
         if self.data_aspect:
             return (yspan/xspan)*self.data_aspect
         elif self.aspect == 'equal':
-            return xspan/yspan
+            return yspan/xspan
         elif self.aspect == 'square':
             return 1
         elif self.aspect is not None:

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -769,9 +769,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
         categorical = isinstance(xaxis, CategoricalAxis) or isinstance(yaxis, CategoricalAxis)
         datetime = isinstance(xaxis, DatetimeAxis) or isinstance(yaxis, CategoricalAxis)
 
-        if data_aspect and fixed_width and fixed_height:
-            pass
-        elif data_aspect and (categorical or datetime):
+        if data_aspect and (categorical or datetime):
             ax_type = 'categorical' if categorical else 'datetime axes'
             self.param.warning('Cannot set data_aspect if one or both '
                                'axes are %s, the option will '
@@ -780,7 +778,8 @@ class ElementPlot(BokehPlot, GenericElementPlot):
             plot = self.handles['plot']
             xspan = r-l if util.is_number(l) and util.is_number(r) else None
             yspan = t-b if util.is_number(b) and util.is_number(t) else None
-            if self.drawn or self.aspect not in ['equal', None]:
+
+            if self.drawn or self.aspect != 'equal':
                 # After initial draw or if aspect is explicit
                 # adjust range to match the plot dimension aspect
                 ratio = self.data_aspect or 1
@@ -804,7 +803,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
                     xpad = (desired_xspan-xspan)/2.
                     l, r = l-xpad, r+xpad
                     xupdate = True
-            else:
+            elif not (fixed_height and fixed_width):
                 # Set initial aspect
                 aspect = self.get_aspect(xspan, yspan)
                 width = plot.frame_width or plot.plot_width or 300

--- a/holoviews/plotting/bokeh/util.py
+++ b/holoviews/plotting/bokeh/util.py
@@ -309,7 +309,7 @@ def compute_layout_properties(
     if data_aspect:
         match_aspect = True
         if (fixed_width and fixed_height):
-            frame_width, frame_height = width, height
+            frame_width, frame_height = frame_width or width, frame_height or height
         elif fixed_width or not fixed_height:
             height = None
         elif fixed_height or not fixed_width:

--- a/holoviews/plotting/bokeh/util.py
+++ b/holoviews/plotting/bokeh/util.py
@@ -310,11 +310,10 @@ def compute_layout_properties(
         match_aspect = True
         if (fixed_width and fixed_height):
             frame_width, frame_height = width, height
-        else:
-            if fixed_width or not fixed_height:
-                height = None
-            if fixed_height or not fixed_width:
-                width = None
+        elif fixed_width or not fixed_height:
+            height = None
+        elif fixed_height or not fixed_width:
+            width = None
 
         aspect_scale = data_aspect
         if aspect == 'equal':

--- a/holoviews/plotting/bokeh/util.py
+++ b/holoviews/plotting/bokeh/util.py
@@ -202,7 +202,10 @@ def compute_layout_properties(
     fixed_width = (explicit_width or frame_width)
     fixed_height = (explicit_height or frame_height)
     fixed_aspect = aspect or data_aspect
-    aspect = 1 if aspect == 'square' else aspect
+    if aspect == 'square':
+        aspect = 1
+    elif aspect == 'equal':
+        data_aspect = 1
 
     # Plot dimensions
     height = None if height is None else int(height*size_multiplier)
@@ -250,16 +253,25 @@ def compute_layout_properties(
 
     if fixed_aspect:
         aspect_type = 'data_aspect' if data_aspect else 'aspect'
-        if fixed_width and fixed_height:
-            if not data_aspect:
+        if fixed_width and fixed_height and aspect:
+            if aspect == 'equal':
+                data_aspect = None
+                if logger:
+                    logger.warning(
+                        "%s value was ignored because absolute width and "
+                        "height values were provided. To set the scaling "
+                        "between the x- and y-axis independent of the "
+                        "width and height values set the data_aspect."
+                        % aspect_type)
+            elif not data_aspect:
                 aspect = None
-            if logger:
-                logger.warning(
-                    "%s value was ignored because absolute width and "
-                    "height values were provided. Either supply "
-                    "explicit frame_width and frame_height to achieve "
-                    "desired aspect OR supply a combination of width "
-                    "or height and an aspect value." % aspect_type)
+                if logger:
+                    logger.warning(
+                        "%s value was ignored because absolute width and "
+                        "height values were provided. Either supply "
+                        "explicit frame_width and frame_height to achieve "
+                        "desired aspect OR supply a combination of width "
+                        "or height and an aspect value." % aspect_type)
         elif fixed_width and responsive:
             height = None
             responsive = False
@@ -294,20 +306,23 @@ def compute_layout_properties(
     match_aspect = False
     aspect_scale = 1
     aspect_ratio = None
-    if (fixed_width and fixed_height):
-        pass
-    elif data_aspect or aspect == 'equal':
+    if data_aspect:
         match_aspect = True
-        if fixed_width or not fixed_height:
-            height = None
-        if fixed_height or not fixed_width:
-            width = None
+        if (fixed_width and fixed_height):
+            frame_width, frame_height = width, height
+        else:
+            if fixed_width or not fixed_height:
+                height = None
+            if fixed_height or not fixed_width:
+                width = None
 
         aspect_scale = data_aspect
         if aspect == 'equal':
             aspect_scale = 1
         elif responsive:
             aspect_ratio = aspect
+    elif (fixed_width and fixed_height):
+        pass
     elif isnumeric(aspect):
         if responsive:
             aspect_ratio = aspect

--- a/holoviews/tests/plotting/bokeh/testelementplot.py
+++ b/holoviews/tests/plotting/bokeh/testelementplot.py
@@ -459,7 +459,7 @@ class TestElementPlot(LoggingComparisonTestCase, TestBokehPlot):
         self.assertEqual(plot.state.plot_height, None)
         self.assertEqual(plot.state.plot_width, None)
         self.assertEqual(plot.state.frame_height, 300)
-        self.assertEqual(plot.state.frame_width, 225)
+        self.assertEqual(plot.state.frame_width, 400)
         self.assertEqual(plot.state.aspect_scale, 1.5)
 
     def test_element_data_aspect_width(self):
@@ -481,19 +481,23 @@ class TestElementPlot(LoggingComparisonTestCase, TestBokehPlot):
         self.assertEqual(plot.state.aspect_scale, 2)
 
     def test_element_data_aspect_width_height(self):
-        curve = Curve([1, 2, 3]).opts(data_aspect=2, height=400, width=400)
+        curve = Curve([0, 2, 3]).opts(data_aspect=2, height=400, width=400)
         plot = bokeh_renderer.get_plot(curve)
-        self.log_handler.assertContains('WARNING', "data_aspect value was ignored")
+        x_range, y_range = plot.handles['x_range'], plot.handles['y_range']
         self.assertEqual(plot.state.plot_height, 400)
         self.assertEqual(plot.state.plot_width, 400)
-        self.assertEqual(plot.state.aspect_scale, 1)
+        self.assertEqual(plot.state.aspect_scale, 2)
+        self.assertEqual(x_range.start, 0)
+        self.assertEqual(x_range.end, 2)
+        self.assertEqual(y_range.start, -0.5)
+        self.assertEqual(y_range.end, 3.5)
 
     def test_element_data_aspect_frame_width(self):
         curve = Curve([1, 2, 3]).opts(data_aspect=2, frame_width=400)
         plot = bokeh_renderer.get_plot(curve)
         self.assertEqual(plot.state.plot_height, None)
         self.assertEqual(plot.state.plot_width, None)
-        self.assertEqual(plot.state.frame_height, 200)
+        self.assertEqual(plot.state.frame_height, 800)
         self.assertEqual(plot.state.frame_width, 400)
         self.assertEqual(plot.state.aspect_scale, 2)
 
@@ -503,7 +507,7 @@ class TestElementPlot(LoggingComparisonTestCase, TestBokehPlot):
         self.assertEqual(plot.state.plot_height, None)
         self.assertEqual(plot.state.plot_width, None)
         self.assertEqual(plot.state.frame_height, 400)
-        self.assertEqual(plot.state.frame_width, 800)
+        self.assertEqual(plot.state.frame_width, 200)
         self.assertEqual(plot.state.aspect_scale, 2)
 
     def test_element_data_aspect_frame_width_frame_height(self):
@@ -513,8 +517,7 @@ class TestElementPlot(LoggingComparisonTestCase, TestBokehPlot):
         self.assertEqual(plot.state.plot_width, None)
         self.assertEqual(plot.state.frame_height, 400)
         self.assertEqual(plot.state.frame_width, 400)
-        self.assertEqual(plot.state.aspect_scale, 1)
-        self.log_handler.assertContains('WARNING', "data_aspect value was ignored")
+        self.assertEqual(plot.state.aspect_scale, 2)
 
     #################################################################
     # Aspect tests
@@ -640,13 +643,13 @@ class TestElementPlot(LoggingComparisonTestCase, TestBokehPlot):
     def test_element_data_aspect_and_aspect_responsive(self):
         curve = Curve([0, 2]).opts(data_aspect=1, aspect=2, responsive=True)
         plot = bokeh_renderer.get_plot(curve)
-        self.assertEqual(plot.state.aspect_ratio, 2)
+        self.assertEqual(plot.state.aspect_ratio, 0.5)
         self.assertEqual(plot.state.aspect_scale, 1)
         self.assertEqual(plot.state.sizing_mode, 'scale_both')
         x_range = plot.handles['x_range']
         y_range = plot.handles['y_range']
-        self.assertEqual(x_range.start, -1.5)
-        self.assertEqual(x_range.end, 2.5)
+        self.assertEqual(x_range.start, 0)
+        self.assertEqual(x_range.end, 1)
         self.assertEqual(y_range.start, 0)
         self.assertEqual(y_range.end, 2)
 
@@ -669,7 +672,7 @@ class TestElementPlot(LoggingComparisonTestCase, TestBokehPlot):
     def test_element_data_aspect_frame_width_responsive(self):
         curve = Curve([1, 2, 3]).opts(data_aspect=2, frame_width=400, responsive=True)
         plot = bokeh_renderer.get_plot(curve)
-        self.assertEqual(plot.state.frame_height, 200)
+        self.assertEqual(plot.state.frame_height, 800)
         self.assertEqual(plot.state.frame_width, 400)
         self.assertEqual(plot.state.sizing_mode, 'fixed')
         self.log_handler.assertContains('WARNING', "responsive mode could not be enabled")
@@ -678,7 +681,7 @@ class TestElementPlot(LoggingComparisonTestCase, TestBokehPlot):
         curve = Curve([1, 2, 3]).opts(data_aspect=2, frame_height=400, responsive=True)
         plot = bokeh_renderer.get_plot(curve)
         self.assertEqual(plot.state.frame_height, 400)
-        self.assertEqual(plot.state.frame_width, 800)
+        self.assertEqual(plot.state.frame_width, 200)
         self.assertEqual(plot.state.sizing_mode, 'fixed')
         self.log_handler.assertContains('WARNING', "responsive mode could not be enabled")
 


### PR DESCRIPTION
This PR allows setting the data_aspect even if a fixed width and height are set by adjusting the plot ranges instead of the width and height of the plot. This is already what data_aspect did after the initialization of a plot so all this changes is that this can now also be done during plot initialization.

This is an important usecase and an unfortunate oversight. I also think there was an issue with inverted handling for data_aspect in certain scenarios.