### PR TITLE
Interface improvements for dask and dtype handling

### DIFF
--- a/holoviews/core/data/array.py
+++ b/holoviews/core/data/array.py
@@ -123,7 +123,7 @@ class ArrayInterface(Interface):
 
 
     @classmethod
-    def values(cls, dataset, dim, expanded=True, flat=True):
+    def values(cls, dataset, dim, expanded=True, flat=True, compute=True):
         data = dataset.data
         dim_idx = dataset.get_dimension_index(dim)
         if data.ndim == 1:

--- a/holoviews/core/data/array.py
+++ b/holoviews/core/data/array.py
@@ -98,6 +98,11 @@ class ArrayInterface(Interface):
 
 
     @classmethod
+    def dtype(cls, dataset, dimension):
+        return dataset.data.dtype
+
+
+    @classmethod
     def add_dimension(cls, dataset, dimension, dim_pos, values, vdim):
         data = dataset.data.copy()
         return np.insert(data, dim_pos, values, axis=1)

--- a/holoviews/core/data/dask.py
+++ b/holoviews/core/data/dask.py
@@ -90,12 +90,12 @@ class DaskInterface(PandasInterface):
         return dataset.data
 
     @classmethod
-    def values(cls, dataset, dim, expanded=True, flat=True):
+    def values(cls, dataset, dim, expanded=True, flat=True, compute=True):
         dim = dataset.get_dimension(dim)
         data = dataset.data[dim.name]
         if not expanded:
             data = data.unique()
-        return data.compute().values
+        return data.compute().values if compute else data.values
 
     @classmethod
     def select_mask(cls, dataset, selection):

--- a/holoviews/core/data/dictionary.py
+++ b/holoviews/core/data/dictionary.py
@@ -246,7 +246,7 @@ class DictInterface(Interface):
 
 
     @classmethod
-    def values(cls, dataset, dim, expanded=True, flat=True):
+    def values(cls, dataset, dim, expanded=True, flat=True, compute=True):
         dim = dataset.get_dimension(dim).name
         values = dataset.data.get(dim)
         if isscalar(values):

--- a/holoviews/core/data/image.py
+++ b/holoviews/core/data/image.py
@@ -78,6 +78,15 @@ class ImageInterface(GridInterface):
 
 
     @classmethod
+    def dtype(cls, dataset, dimension):
+        idx = dataset.get_dimension_index(dimension)
+        if idx in [0, 1]:
+            return np.dtype('float')
+        else:
+            return dataset.data.dtype
+
+
+    @classmethod
     def length(cls, dataset):
         return np.product(dataset.data.shape[:2], dtype=np.intp)
 

--- a/holoviews/core/data/interface.py
+++ b/holoviews/core/data/interface.py
@@ -273,6 +273,12 @@ class Interface(param.Parameterized):
 
 
     @classmethod
+    def dtype(cls, dataset, dimension):
+        name = dataset.get_dimension(dimension, strict=True).name
+        return dataset.data[name].dtype
+
+
+    @classmethod
     def select_mask(cls, dataset, selection):
         """
         Given a Dataset object and a dictionary with dimension keys and

--- a/holoviews/core/data/multipath.py
+++ b/holoviews/core/data/multipath.py
@@ -281,7 +281,7 @@ class MultiInterface(Interface):
         return new_data
 
     @classmethod
-    def values(cls, dataset, dimension, expanded, flat):
+    def values(cls, dataset, dimension, expanded=True, flat=True, compute=True):
         """
         Returns a single concatenated array of all subpaths separated
         by NaN values. If expanded keyword is False an array of arrays
@@ -293,7 +293,7 @@ class MultiInterface(Interface):
         ds = cls._inner_dataset_template(dataset)
         for d in dataset.data:
             ds.data = d
-            dvals = ds.interface.values(ds, dimension, expanded, flat)
+            dvals = ds.interface.values(ds, dimension, expanded, flat, compute)
             if not len(dvals):
                 continue
             elif expanded:

--- a/holoviews/core/data/multipath.py
+++ b/holoviews/core/data/multipath.py
@@ -259,6 +259,13 @@ class MultiInterface(Interface):
         return length+len(dataset.data)-1
 
     @classmethod
+    def dtype(cls, dataset, dimension):
+        if not dataset.data:
+            return np.dtype('float')
+        ds = cls._inner_dataset_template(dataset)
+        return ds.interface.dtype(dataset, dimension)
+
+    @classmethod
     def nonzero(cls, dataset):
         return bool(dataset.data)
 

--- a/holoviews/core/data/pandas.py
+++ b/holoviews/core/data/pandas.py
@@ -274,7 +274,7 @@ class PandasInterface(Interface):
 
 
     @classmethod
-    def values(cls, dataset, dim, expanded=True, flat=True):
+    def values(cls, dataset, dim, expanded=True, flat=True, compute=True):
         dim = dataset.get_dimension(dim, strict=True)
         data = dataset.data[dim.name]
         if not expanded:

--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -847,11 +847,15 @@ def isfinite(val):
     Helper function to determine if scalar or array value is finite extending
     np.isfinite with support for None, string, datetime types.
     """
-    if not np.isscalar(val):
+    is_dask = is_dask_array(val)
+    if not np.isscalar(val) and not is_dask:
         val = asarray(val, strict=False)
 
     if val is None:
         return False
+    elif is_dask:
+        import dask.array as da
+        return da.isfinite(val)
     elif isinstance(val, np.ndarray):
         if val.dtype.kind == 'M':
             return ~isnat(val)
@@ -1424,7 +1428,7 @@ def is_dataframe(data):
     Checks whether the supplied data is of DataFrame type.
     """
     dd = None
-    if 'dask' in sys.modules and 'pandas' in sys.modules:
+    if 'dask.dataframe' in sys.modules and 'pandas' in sys.modules:
         import dask.dataframe as dd
     return((pd is not None and isinstance(data, pd.DataFrame)) or
           (dd is not None and isinstance(data, dd.DataFrame)))
@@ -1435,10 +1439,17 @@ def is_series(data):
     Checks whether the supplied data is of Series type.
     """
     dd = None
-    if 'dask' in sys.modules:
+    if 'dask.dataframe' in sys.modules:
         import dask.dataframe as dd
     return((pd is not None and isinstance(data, pd.Series)) or
           (dd is not None and isinstance(data, dd.Series)))
+
+
+def is_dask_array(data):
+    da = None
+    if 'dask.array' in sys.modules:
+        import dask.array as da
+    return (da is not None and isinstance(data, da.Array))
 
 
 def get_param_values(data):

--- a/holoviews/operation/element.py
+++ b/holoviews/operation/element.py
@@ -624,7 +624,7 @@ class histogram(Operation):
                 # This covers True, 'height', 'integral'
                 hist, edges = histogram(data, density=True,
                                         weights=weights, bins=edges)
-                if normed=='height':
+                if normed == 'height':
                     hist /= hist.max()
             else:
                 hist, edges = histogram(data, normed=normed, weights=weights, bins=edges)

--- a/holoviews/tests/core/data/base.py
+++ b/holoviews/tests/core/data/base.py
@@ -104,8 +104,8 @@ class HomogeneousColumnTests(object):
         self.assertTrue(isinstance(dataset.data, self.data_type))
 
     def test_dataset_dtypes(self):
-        self.assertEqual(self.dataset_hm.interface.dtype(self.dataset_hm, 'x'), np.int64)
-        self.assertEqual(self.dataset_hm.interface.dtype(self.dataset_hm, 'y'), np.int64)
+        self.assertEqual(self.dataset_hm.interface.dtype(self.dataset_hm, 'x'), np.dtype(int))
+        self.assertEqual(self.dataset_hm.interface.dtype(self.dataset_hm, 'y'), np.dtype(int))
 
     def test_dataset_array_init_hm_tuple_dims(self):
         dataset = Dataset(np.column_stack([self.xs, self.xs_2]),
@@ -449,8 +449,8 @@ class HeterogeneousColumnTests(HomogeneousColumnTests):
     def test_dataset_dataset_ht_dtypes(self):
         ds = self.table
         self.assertEqual(ds.interface.dtype(ds, 'Gender'), np.dtype('object'))
-        self.assertEqual(ds.interface.dtype(ds, 'Age'), np.dtype('int64'))
-        self.assertEqual(ds.interface.dtype(ds, 'Weight'), np.dtype('int64'))
+        self.assertEqual(ds.interface.dtype(ds, 'Age'), np.dtype(int))
+        self.assertEqual(ds.interface.dtype(ds, 'Weight'), np.dtype(int))
         self.assertEqual(ds.interface.dtype(ds, 'Height'), np.dtype('float64'))
 
     # Test literal formats
@@ -916,9 +916,9 @@ class GriddedInterfaceTests(object):
 
     def test_gridded_dtypes(self):
         ds = self.dataset_grid
-        self.assertEqual(ds.interface.dtype(ds, 'x'), np.int64)
+        self.assertEqual(ds.interface.dtype(ds, 'x'), np.dtype(int))
         self.assertEqual(ds.interface.dtype(ds, 'y'), np.float64)
-        self.assertEqual(ds.interface.dtype(ds, 'z'), np.int64)
+        self.assertEqual(ds.interface.dtype(ds, 'z'), np.dtype(int))
 
     def test_select_slice(self):
         ds = self.element(

--- a/holoviews/tests/core/data/base.py
+++ b/holoviews/tests/core/data/base.py
@@ -103,6 +103,10 @@ class HomogeneousColumnTests(object):
                           kdims=['x'], vdims=['x2'])
         self.assertTrue(isinstance(dataset.data, self.data_type))
 
+    def test_dataset_dtypes(self):
+        self.assertEqual(self.dataset_hm.interface.dtype(self.dataset_hm, 'x'), np.int64)
+        self.assertEqual(self.dataset_hm.interface.dtype(self.dataset_hm, 'y'), np.int64)
+
     def test_dataset_array_init_hm_tuple_dims(self):
         dataset = Dataset(np.column_stack([self.xs, self.xs_2]),
                           kdims=[('x', 'X')], vdims=[('x2', 'X2')])
@@ -439,6 +443,15 @@ class HeterogeneousColumnTests(HomogeneousColumnTests):
         dataset = Dataset(pd.DataFrame({'x':self.xs, 'y':self.ys}),
                           kdims=[('x', 'X')], vdims=[('y', 'Y')])
         self.assertTrue(isinstance(dataset.data, self.data_type))
+
+    # Test dtypes
+
+    def test_dataset_dataset_ht_dtypes(self):
+        ds = self.table
+        self.assertEqual(ds.interface.dtype(ds, 'Gender'), np.dtype('object'))
+        self.assertEqual(ds.interface.dtype(ds, 'Age'), np.dtype('int64'))
+        self.assertEqual(ds.interface.dtype(ds, 'Weight'), np.dtype('int64'))
+        self.assertEqual(ds.interface.dtype(ds, 'Height'), np.dtype('float64'))
 
     # Test literal formats
 
@@ -900,6 +913,12 @@ class GriddedInterfaceTests(object):
                               [ 0.06925999,  0.05800389,  0.05620127]])
         self.assertEqual(dataset.dimension_values('z', flat=False),
                          canonical)
+
+    def test_gridded_dtypes(self):
+        ds = self.dataset_grid
+        self.assertEqual(ds.interface.dtype(ds, 'x'), np.int64)
+        self.assertEqual(ds.interface.dtype(ds, 'y'), np.float64)
+        self.assertEqual(ds.interface.dtype(ds, 'z'), np.int64)
 
     def test_select_slice(self):
         ds = self.element(

--- a/holoviews/tests/core/data/testarrayinterface.py
+++ b/holoviews/tests/core/data/testarrayinterface.py
@@ -18,6 +18,11 @@ class ArrayDatasetTest(HomogeneousColumnTests, InterfaceTests):
         for d in 'xy':
             self.assertEqual(dataset.dimension_values(d).dtype, np.float64)
 
+    def test_dataset_empty_list_dtypes(self):
+        dataset = Dataset([], kdims=['x'], vdims=['y'])
+        for d in 'xy':
+            self.assertEqual(dataset.interface.dtype(dataset, d), np.float64)
+
     def test_dataset_simple_dict_sorted(self):
         dataset = Dataset({2: 2, 1: 1, 3: 3}, kdims=['x'], vdims=['y'])
         self.assertEqual(dataset, Dataset([(i, i) for i in range(1, 4)],

--- a/holoviews/tests/core/data/testdictinterface.py
+++ b/holoviews/tests/core/data/testdictinterface.py
@@ -1,4 +1,7 @@
+import sys
+
 from collections import OrderedDict
+
 import numpy as np
 
 from holoviews.core.dimension import OrderedDict as cyODict
@@ -22,7 +25,8 @@ class DictDatasetTest(HeterogeneousColumnTests, ScalarColumnTests, InterfaceTest
 
     def test_dataset_dataset_ht_dtypes(self):
         ds = self.table
-        self.assertEqual(ds.interface.dtype(ds, 'Gender'), np.dtype('<U1'))
+        str_type = '<U1' if sys.version_info.major >= 3 else 'S1'
+        self.assertEqual(ds.interface.dtype(ds, 'Gender'), np.dtype(str_type))
         self.assertEqual(ds.interface.dtype(ds, 'Age'), np.dtype('int64'))
         self.assertEqual(ds.interface.dtype(ds, 'Weight'), np.dtype('int64'))
         self.assertEqual(ds.interface.dtype(ds, 'Height'), np.dtype('float64'))

--- a/holoviews/tests/core/data/testdictinterface.py
+++ b/holoviews/tests/core/data/testdictinterface.py
@@ -27,8 +27,8 @@ class DictDatasetTest(HeterogeneousColumnTests, ScalarColumnTests, InterfaceTest
         ds = self.table
         str_type = '<U1' if sys.version_info.major >= 3 else 'S1'
         self.assertEqual(ds.interface.dtype(ds, 'Gender'), np.dtype(str_type))
-        self.assertEqual(ds.interface.dtype(ds, 'Age'), np.dtype('int64'))
-        self.assertEqual(ds.interface.dtype(ds, 'Weight'), np.dtype('int64'))
+        self.assertEqual(ds.interface.dtype(ds, 'Age'), np.dtype(int))
+        self.assertEqual(ds.interface.dtype(ds, 'Weight'), np.dtype(int))
         self.assertEqual(ds.interface.dtype(ds, 'Height'), np.dtype('float64'))
 
     def test_dataset_empty_list_init_dtypes(self):

--- a/holoviews/tests/core/data/testdictinterface.py
+++ b/holoviews/tests/core/data/testdictinterface.py
@@ -20,6 +20,13 @@ class DictDatasetTest(HeterogeneousColumnTests, ScalarColumnTests, InterfaceTest
         self.assertEqual(dataset, Dataset([(i, i) for i in range(1, 4)],
                                           kdims=['x'], vdims=['y']))
 
+    def test_dataset_dataset_ht_dtypes(self):
+        ds = self.table
+        self.assertEqual(ds.interface.dtype(ds, 'Gender'), np.dtype('<U1'))
+        self.assertEqual(ds.interface.dtype(ds, 'Age'), np.dtype('int64'))
+        self.assertEqual(ds.interface.dtype(ds, 'Weight'), np.dtype('int64'))
+        self.assertEqual(ds.interface.dtype(ds, 'Height'), np.dtype('float64'))
+
     def test_dataset_empty_list_init_dtypes(self):
         dataset = Dataset([], kdims=['x'], vdims=['y'])
         for d in 'xy':

--- a/holoviews/tests/core/data/testimageinterface.py
+++ b/holoviews/tests/core/data/testimageinterface.py
@@ -31,6 +31,12 @@ class ImageInterfaceTests(GriddedInterfaceTests, InterfaceTests):
         self.assertEqual(dataset.dimension_values('z', flat=False),
                          canonical)
 
+    def test_gridded_dtypes(self):
+        ds = self.dataset_grid
+        self.assertEqual(ds.interface.dtype(ds, 'x'), np.float64)
+        self.assertEqual(ds.interface.dtype(ds, 'y'), np.float64)
+        self.assertEqual(ds.interface.dtype(ds, 'z'), np.int64)
+
     def test_dataset_groupby_with_transposed_dimensions(self):
         raise SkipTest('Image interface does not support multi-dimensional data.')
 

--- a/holoviews/tests/core/data/testimageinterface.py
+++ b/holoviews/tests/core/data/testimageinterface.py
@@ -35,7 +35,7 @@ class ImageInterfaceTests(GriddedInterfaceTests, InterfaceTests):
         ds = self.dataset_grid
         self.assertEqual(ds.interface.dtype(ds, 'x'), np.float64)
         self.assertEqual(ds.interface.dtype(ds, 'y'), np.float64)
-        self.assertEqual(ds.interface.dtype(ds, 'z'), np.int64)
+        self.assertEqual(ds.interface.dtype(ds, 'z'), np.dtype(int))
 
     def test_dataset_groupby_with_transposed_dimensions(self):
         raise SkipTest('Image interface does not support multi-dimensional data.')


### PR DESCRIPTION
* Adds an ``Interface.dtype`` method to inspect dtypes without loading data
* Adds Interface.values ``compute`` argument to access dask arrays without loading them into memory