### PR TITLE
Propagate backend argument to Store.lookup_options

### DIFF
--- a/holoviews/core/options.py
+++ b/holoviews/core/options.py
@@ -723,7 +723,7 @@ class OptionTree(AttrTree):
         return item if mode == 'node' else item.path
 
 
-    def closest(self, obj, group, defaults=True):
+    def closest(self, obj, group, defaults=True, backend=None):
         """
         This method is designed to be called from the root of the
         tree. Given any LabelledData object, this method will return
@@ -737,11 +737,11 @@ class OptionTree(AttrTree):
                       label_sanitizer(obj.label))
         target = '.'.join([c for c in components if c])
         return self.find(components).options(group, target=target,
-                                             defaults=defaults)
+                                             defaults=defaults, backend=backend)
 
 
 
-    def options(self, group, target=None, defaults=True):
+    def options(self, group, target=None, defaults=True, backend=None):
         """
         Using inheritance up to the root, get the complete Options
         object for the given node and the specified group.
@@ -750,19 +750,19 @@ class OptionTree(AttrTree):
             target = self.path
         if self.groups.get(group, None) is None:
             return None
-        if self.parent is None and target and (self is not Store.options()) and defaults:
+        if self.parent is None and target and (self is not Store.options(backend=backend)) and defaults:
             root_name = self.__class__.__name__
             replacement = root_name + ('' if len(target) == len(root_name) else '.')
             option_key = target.replace(replacement,'')
-            match = Store.options().find(option_key)
-            if match is not Store.options():
+            match = Store.options(backend=backend).find(option_key)
+            if match is not Store.options(backend=backend):
                 return match.options(group)
             else:
                 return Options()
         elif self.parent is None:
             return self.groups[group]
 
-        parent_opts = self.parent.options(group,target, defaults)
+        parent_opts = self.parent.options(group,target, defaults, backend=backend)
         return Options(**dict(parent_opts.kwargs, **self.groups[group].kwargs))
 
     def __repr__(self):
@@ -1226,9 +1226,10 @@ class Store(object):
     def lookup_options(cls, backend, obj, group, defaults=True):
         # Current custom_options dict may not have entry for obj.id
         if obj.id in cls._custom_options[backend]:
-            return cls._custom_options[backend][obj.id].closest(obj, group, defaults)
+            return cls._custom_options[backend][obj.id].closest(
+                obj, group, defaults, backend=backend)
         elif defaults:
-            return cls._options[backend].closest(obj, group, defaults)
+            return cls._options[backend].closest(obj, group, defaults, backend=backend)
         else:
             return OptionTree(groups=cls._options[backend].groups)
 

--- a/holoviews/tests/core/testoptions.py
+++ b/holoviews/tests/core/testoptions.py
@@ -3,7 +3,7 @@ import pickle
 from unittest import SkipTest
 
 import numpy as np
-from holoviews import Store, Histogram, Image, Curve, DynamicMap, opts
+from holoviews import Store, Histogram, Image, Curve, Points, DynamicMap, opts
 from holoviews.core.options import (
     OptionError, Cycle, Options, OptionTree, StoreOptions, options_policy
 )
@@ -21,6 +21,12 @@ except:
 try:
     # Needed to register backend  and options
     from holoviews.plotting import bokeh # noqa
+except:
+    pass
+
+try:
+    # Needed to register backend  and options
+    from holoviews.plotting import plotly # noqa
 except:
     pass
 
@@ -936,6 +942,37 @@ class TestCrossBackendOptions(ComparisonTestCase):
                "type across all extensions. No similar options found.")
         with self.assertRaisesRegexp(ValueError, err):
             opts.Curve(foobar=3)
+
+
+class TestLookupOptions(ComparisonTestCase):
+
+    def test_lookup_options_honors_backend(self):
+        points = Points([[1, 2], [3, 4]])
+
+        # Lookup points style options with matplotlib and plotly backends while current
+        # backend is bokeh
+        Store.current_backend = 'bokeh'
+        options_matplotlib = Store.lookup_options("matplotlib", points, "style")
+        options_plotly = Store.lookup_options("plotly", points, "style")
+
+        # Lookup points style options with bokeh backend while current
+        # backend is matplotlib
+        Store.current_backend = 'matplotlib'
+        options_bokeh = Store.lookup_options("bokeh", points, "style")
+
+        # Check matplotlib style options
+        for opt in ["cmap", "color", "marker"]:
+            self.assertIn(opt, options_matplotlib.keys())
+        self.assertNotIn("muted_alpha", options_matplotlib.keys())
+
+        # Check bokeh style options
+        for opt in ["cmap", "color", "muted_alpha", "size"]:
+            self.assertIn(opt, options_bokeh.keys())
+
+        # Check plotly style options
+        for opt in ["color"]:
+            self.assertIn(opt, options_plotly.keys())
+        self.assertNotIn("muted_alpha", options_matplotlib.keys())
 
 
 class TestCrossBackendOptionSpecification(ComparisonTestCase):


### PR DESCRIPTION
Closes https://github.com/pyviz/panel/issues/566

The underlying issue is that the `backend` argument to `Store.lookup_options` was not passed along to the `closest` and `options` methods.  So the input backend was effectively ignored.



