### PR TITLE
fixed "OSError: [Errno 22] Invalid argument" for dates < 1970 on Windows

### DIFF
--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -1846,7 +1846,7 @@ def dt64_to_dt(dt64):
     Safely converts NumPy datetime64 to a datetime object.
     """
     ts = (dt64 - np.datetime64('1970-01-01T00:00:00')) / np.timedelta64(1, 's')
-    return dt.datetime.utcfromtimestamp(ts)
+    return dt.datetime(1970,1,1,0,0,0) + dt.timedelta(seconds=ts)
 
 
 def is_nan(x):


### PR DESCRIPTION
The conversion to datetime object threw an error if dates before 1970-01-01 were passed (negative timestamp). Should be fixed.