### PR TITLE
Add extend for plot

### DIFF
--- a/holoviews/plotting/mpl/element.py
+++ b/holoviews/plotting/mpl/element.py
@@ -663,10 +663,6 @@ class ColorbarPlot(ElementPlot):
        User-specified colorbar axis range limits for the plot, as a tuple (low,high).
        If specified, takes precedence over data and dimension ranges.""")
 
-    cformatter = param.ClassSelector(
-        default=None, class_=(util.basestring, ticker.Formatter, FunctionType), doc="""
-        Formatter for ticks along the colorbar axis.""")
-
     colorbar = param.Boolean(default=False, doc="""
         Whether to draw a colorbar.""")
 
@@ -778,7 +774,6 @@ class ColorbarPlot(ElementPlot):
             cax = fig.add_axes([l+w+padding+(scaled_w+padding+w*0.15)*offset,
                                 b, scaled_w, h])
             cbar = fig.colorbar(artist, cax=cax, ax=axis, extend=self.extend)
-            self._set_axis_formatter(cbar.ax.yaxis, dimension, self.cformatter)
             self._adjust_cbar(cbar, label, dimension)
             self.handles['cax'] = cax
             self.handles['cbar'] = cbar

--- a/holoviews/plotting/mpl/element.py
+++ b/holoviews/plotting/mpl/element.py
@@ -695,13 +695,13 @@ class ColorbarPlot(ElementPlot):
     cbar_width = param.Number(default=0.05, doc="""
         Width of the colorbar as a fraction of the main plot""")
 
-    symmetric = param.Boolean(default=False, doc="""
-        Whether to make the colormap symmetric around zero.""")
-
-    extend = param.ObjectSelector(
+    cbar_extend = param.ObjectSelector(
         objects=['neither', 'both', 'min', 'max'], default=None, doc="""
         If not 'neither', make pointed end(s) for out-of- range values."""
     )
+
+    symmetric = param.Boolean(default=False, doc="""
+        Whether to make the colormap symmetric around zero.""")
 
     _colorbars = {}
 
@@ -777,7 +777,7 @@ class ColorbarPlot(ElementPlot):
             scaled_w = w*width
             cax = fig.add_axes([l+w+padding+(scaled_w+padding+w*0.15)*offset,
                                 b, scaled_w, h])
-            cbar = fig.colorbar(artist, cax=cax, ax=axis, extend=self.extend)
+            cbar = fig.colorbar(artist, cax=cax, ax=axis, extend=self.cbar_extend)
             self._set_axis_formatter(cbar.ax.yaxis, dimension, self.cformatter)
             self._adjust_cbar(cbar, label, dimension)
             self.handles['cax'] = cax
@@ -894,15 +894,15 @@ class ColorbarPlot(ElementPlot):
             el_min, el_max = -np.inf, np.inf
         vmin = -np.inf if opts[prefix+'vmin'] is None else opts[prefix+'vmin']
         vmax = np.inf if opts[prefix+'vmax'] is None else opts[prefix+'vmax']
-        if self.extend is None:
+        if self.cbar_extend is None:
             if el_min < vmin and el_max > vmax:
-                self.extend = 'both'
+                self.cbar_extend = 'both'
             elif el_min < vmin:
-                self.extend = 'min'
+                self.cbar_extend = 'min'
             elif el_max > vmax:
-                self.extend = 'max'
+                self.cbar_extend = 'max'
             else:
-                self.extend = 'neither'
+                self.cbar_extend = 'neither'
 
         # Define special out-of-range colors on colormap
         colors = {}

--- a/holoviews/plotting/mpl/element.py
+++ b/holoviews/plotting/mpl/element.py
@@ -695,9 +695,9 @@ class ColorbarPlot(ElementPlot):
         Whether to make the colormap symmetric around zero.""")
 
     extend = param.ObjectSelector(
-        objects=['neither', 'both', 'min', 'max'], default=None, docs="""
+        objects=['neither', 'both', 'min', 'max'], default=None, doc="""
         If not 'neither', make pointed end(s) for out-of- range values."""
-        )
+    )
 
     _colorbars = {}
 


### PR DESCRIPTION
The main reason why I want to set this manually is so if I have an animation and the min/max goes out of range, it doesn't awkwardly make rectangular edges into triangular and adjust the plot position