### PR TITLE
Refactored datashader operations and add new aggregators

### DIFF
--- a/examples/user_guide/15-Large_Data.ipynb
+++ b/examples/user_guide/15-Large_Data.ipynb
@@ -194,7 +194,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "![](http://assets.holoviews.org/gifs/guides/user_guide/Large_Data/rasterize_color_range.gif)"
+    "<img src=\"http://assets.holoviews.org/gifs/guides/user_guide/Large_Data/rasterize_color_range.gif\"></img>"
    ]
   },
   {
@@ -363,7 +363,13 @@
     "\n",
     "# Hover info\n",
     "\n",
-    "As you can see in the examples above, converting the data to an image using Datashader makes it feasible to work with even very large datasets interactively.  One unfortunate side effect is that the original datapoints and line segments can no longer be used to support \"tooltips\" or \"hover\" information directly for RGB images generated with `datashade`; that data simply is not present at the browser level, and so the browser cannot unambiguously report information about any specific datapoint. Luckily, you can still provide hover information that reports properties of a subset of the data in a separate layer (as above), or you can provide information for a spatial region of the plot rather than for specific datapoints.  For instance, in some small rectangle you can provide statistics such as the mean, count, standard deviation, etc:"
+    "As you can see in the examples above, converting the data to an image using Datashader makes it feasible to work with even very large datasets interactively.  One unfortunate side effect is that the original datapoints and line segments can no longer be used to support \"tooltips\" or \"hover\" information directly for RGB images generated with `datashade`; that data simply is not present at the browser level, and so the browser cannot unambiguously report information about any specific datapoint. \n",
+    "\n",
+    "Additionally once the ``shade`` operation is applied any detail about the underlying data is obscured. In order to get hover information there are therefore two options:\n",
+    "\n",
+    "1) Use the ``rasterize`` operation without `shade`\n",
+    "\n",
+    "2) Overlay a separate layer as a ``QuadMesh`` or ``Image`` containing the hover information"
    ]
   },
   {
@@ -374,20 +380,24 @@
    "source": [
     "from holoviews.streams import RangeXY\n",
     "\n",
+    "rasterized = rasterize(points, width=400, height=400)\n",
+    "\n",
     "fixed_hover = (datashade(points, width=400, height=400) *  \n",
     "               hv.QuadMesh(rasterize(points, width=10, height=10, dynamic=False)))\n",
     "\n",
     "dynamic_hover = (datashade(points, width=400, height=400) * \n",
-    "                 hv.util.Dynamic(rasterize(points, width=10, height=10, streams=[RangeXY]), operation=hv.QuadMesh))\n",
+    "                 rasterize(points, width=10, height=10, streams=[RangeXY]).apply(hv.QuadMesh))\n",
     "\n",
-    "(fixed_hover + dynamic_hover).opts(opts.QuadMesh(tools=['hover'], alpha=0, hover_alpha=0.2))"
+    "(rasterized + fixed_hover + dynamic_hover).opts(\n",
+    "    opts.QuadMesh(tools=['hover'], alpha=0, hover_alpha=0.2), \n",
+    "    opts.Image(tools=['hover']))"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In the above examples, the plot on the left provides hover information at a fixed spatial scale, while the one on the right reports on an area that scales with the zoom level so that arbitrarily small regions of data space can be examined, which is generally more useful (but requires a live Python server). Note that you can activate the hover tool for `Image` elements output by the `rasterize` operation."
+    "In the above examples, the plot on the left provides hover information directly on the aggregated ``Image``. The middle plot displays hover information as a ``QuadMesh`` at a fixed spatial scale, while the one on the right reports on an area that scales with the zoom level so that arbitrarily small regions of data space can be examined, which is generally more useful (but requires a live Python server)."
    ]
   },
   {
@@ -444,7 +454,7 @@
     "opts.defaults(\n",
     "    opts.Image(aspect=1, axiswise=True, xaxis='bare', yaxis='bare'),\n",
     "    opts.RGB(aspect=1, axiswise=True, xaxis='bare', yaxis='bare'),\n",
-    "    opts.Layout(vspace=0.1, hspace=0.1, sublabel_format=\"\"))\n",
+    "    opts.Layout(vspace=0.1, hspace=0.1, sublabel_format=\"\", fig_size=80))\n",
     "\n",
     "np.random.seed(12)\n",
     "N=100\n",
@@ -464,6 +474,9 @@
     "\n",
     "shadeable  = [elemtype(pts) for elemtype in [hv.Curve, hv.Scatter, hv.Points]]\n",
     "shadeable += [hv.Path([pts])]\n",
+    "shadeable += [hv.Spikes(np.random.randn(10000))]\n",
+    "shadeable += [hv.Area(np.random.randn(10000).cumsum())]\n",
+    "shadeable += [hv.Spread((np.arange(10000), np.random.randn(10000).cumsum(), np.random.randn(10000)*10))]\n",
     "shadeable += [hv.Image((x,y,z)), hv.QuadMesh((x,y,z))]\n",
     "shadeable += [hv.Graph(((np.zeros(N), np.arange(N)),))]\n",
     "shadeable += [tri.edgepaths]\n",
@@ -491,8 +504,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "rgb_opts = opts.RGB(aspect=1, axiswise=True, xaxis='bare', yaxis='bare')\n",
-    "hv.Layout([e.relabel(e.__class__.name).opts(rgb_opts) for e in shadeable + rasterizable]).cols(6)"
+    "el_opts = dict(aspect=1, axiswise=True, xaxis='bare', yaxis='bare')\n",
+    "hv.Layout([e.relabel(e.__class__.name).opts(**el_opts) for e in shadeable + rasterizable]).cols(6)"
    ]
   },
   {

--- a/examples/user_guide/15-Large_Data.ipynb
+++ b/examples/user_guide/15-Large_Data.ipynb
@@ -365,9 +365,9 @@
     "\n",
     "As you can see in the examples above, converting the data to an image using Datashader makes it feasible to work with even very large datasets interactively.  One unfortunate side effect is that the original datapoints and line segments can no longer be used to support \"tooltips\" or \"hover\" information directly for RGB images generated with `datashade`; that data simply is not present at the browser level, and so the browser cannot unambiguously report information about any specific datapoint. \n",
     "\n",
-    "Additionally once the ``shade`` operation is applied any detail about the underlying data is obscured. In order to get hover information there are therefore two options:\n",
+    "If you do need hover information, there are two good options available:\n",
     "\n",
-    "1) Use the ``rasterize`` operation without `shade`\n",
+    "1) Use the ``rasterize`` operation without `shade`, which will let the plotting code handle the conversion to colors while still having the actual aggregated data to support hovering\n",
     "\n",
     "2) Overlay a separate layer as a ``QuadMesh`` or ``Image`` containing the hover information"
    ]

--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -547,7 +547,9 @@ class overlay_aggregate(aggregate):
 
 class area_aggregate(AggregationOperation):
     """
-    Aggregates Area elements
+    Aggregates Area elements by filling the area between zero and
+    the y-values if only one value dimension is defined and the area
+    between the curves if two are provided.
     """
 
     def _process(self, element, key=None):
@@ -583,6 +585,9 @@ class area_aggregate(AggregationOperation):
         params = dict(get_param_values(element), kdims=[x, y], vdims=vdim,
                       datatype=['xarray'], bounds=(x0, y0, x1, y1))
 
+        if width == 0 or height == 0:
+            return self._empty_agg(element, x, y, width, height, xs, ys, agg_fn, **params)
+
         agg = cvs.area(df, x.name, y.name, agg_fn, axis=0, y_stack=ystack)
         if xtype == "datetime":
             agg[x.name] = (agg[x.name]/1e3).astype('datetime64[us]')
@@ -593,7 +598,8 @@ class area_aggregate(AggregationOperation):
 
 class spread_aggregate(area_aggregate):
     """
-    Aggregates Spread elements
+    Aggregates Spread elements by filling the area between the lower
+    and upper error band.
     """
 
     def _process(self, element, key=None):
@@ -613,7 +619,9 @@ class spread_aggregate(area_aggregate):
 
 class spikes_aggregate(AggregationOperation):
     """
-    Aggregates Spikes element
+    Aggregates Spikes elements by drawing individual line segments
+    over the entire y_range if no value dimension is defined and 
+    between zero and the y-value if one is defined.
     """
     def _process(self, element, key=None):
         agg_fn = self._get_aggregator(element)

--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -22,7 +22,6 @@ except:
 from ..core import (Operation, Element, Dimension, NdOverlay,
                     CompositeOverlay, Dataset, Overlay)
 from ..core.data import PandasInterface, XArrayInterface
-from ..core.sheetcoords import BoundingBox
 from ..core.util import (
     LooseVersion, basestring, cftime_types, cftime_to_timestamp,
     datetime_types, dt_to_int, get_param_values)
@@ -148,7 +147,6 @@ class ResamplingOperation(LinkableOperation):
             xstart, xend = 0, 0
             if element.get_dimension_type(x) in datetime_types:
                 xtype = 'datetime'
-        x_range = (xstart, xend)
 
         ytype = 'numeric'
         if isinstance(ystart, datetime_types) or isinstance(yend, datetime_types):
@@ -158,7 +156,6 @@ class ResamplingOperation(LinkableOperation):
             ystart, yend = 0, 0
             if element.get_dimension_type(y) in datetime_types:
                 ytype = 'datetime'
-        y_range = (ystart, yend)
 
         # Compute highest allowed sampling density
         xspan = xend - xstart
@@ -178,8 +175,18 @@ class ResamplingOperation(LinkableOperation):
         xs, ys = (np.linspace(xstart+xunit/2., xend-xunit/2., width),
                   np.linspace(ystart+yunit/2., yend-yunit/2., height))
 
-        return (x_range, y_range), (xs, ys), (width, height), (xtype, ytype)
+        return ((xstart, xend), (ystart, yend)), (xs, ys), (width, height), (xtype, ytype)
 
+
+    def _dt_transform(self, x_range, y_range, xs, ys, xtype, ytype):
+        (xstart, xend), (ystart, yend) = x_range, y_range
+        if xtype == 'datetime':
+            xstart, xend = (np.array([xstart, xend])/1e3).astype('datetime64[us]')
+            xs = (xs/1e3).astype('datetime64[us]')
+        if ytype == 'datetime':
+            ystart, yend = (np.array([ystart, yend])/1e3).astype('datetime64[us]')
+            ys = (ys/1e3).astype('datetime64[us]')
+        return ((xstart, xend), (ystart, yend)), (xs, ys)
 
 
 class AggregationOperation(ResamplingOperation):
@@ -238,6 +245,41 @@ class AggregationOperation(ResamplingOperation):
                                  'aggregator.' % type(self).__name__)
             agg = type(agg)(field)
         return agg
+
+    def _empty_agg(self, element, x, y, width, height, xs, ys, agg_fn, **params):
+        x = x.name if x else 'x'
+        y = y.name if x else 'y'
+        xarray = xr.DataArray(np.full((height, width), np.NaN),
+                              dims=[y, x], coords={x: xs, y: ys})
+        if width == 0:
+            params['xdensity'] = 1
+        if height == 0:
+            params['ydensity'] = 1
+        el = self.p.element_type(xarray, **params)
+        if isinstance(agg_fn, ds.count_cat):
+            vals = element.dimension_values(agg_fn.column, expanded=False)
+            dim = element.get_dimension(agg_fn.column)
+            return NdOverlay({v: el for v in vals}, dim)
+        return el
+
+    def _get_agg_params(self, element, x, y, agg_fn, bounds):
+        params = dict(get_param_values(element), kdims=[x, y],
+                      datatype=['xarray'], bounds=bounds)
+
+        column = agg_fn.column if agg_fn else None
+        if column:
+            dims = [d for d in element.dimensions('ranges') if d == column]
+            if not dims:
+                raise ValueError("Aggregation column %s not found on %s element. "
+                                 "Ensure the aggregator references an existing "
+                                 "dimension." % (column,element))
+            name = '%s Count' % column if isinstance(agg_fn, ds.count_cat) else column
+            vdims = [dims[0](name)]
+        else:
+            vdims = Dimension('Count')
+        params['vdims'] = vdims
+        return params
+
 
 
 class aggregate(AggregationOperation):
@@ -340,28 +382,99 @@ class aggregate(AggregationOperation):
         return x, y, Dataset(df, kdims=kdims, vdims=vdims), glyph
 
 
-    def _aggregate_ndoverlay(self, element, agg_fn):
-        """
-        Optimized aggregation for NdOverlay objects by aggregating each
-        Element in an NdOverlay individually avoiding having to concatenate
-        items in the NdOverlay. Works by summing sum and count aggregates and
-        applying appropriate masking for NaN values. Mean aggregation
-        is also supported by dividing sum and count aggregates. count_cat
-        aggregates are grouped by the categorical dimension and a separate
-        aggregate for each category is generated.
-        """
+    def _process(self, element, key=None):
+        agg_fn = self._get_aggregator(element)
+        category = agg_fn.column if isinstance(agg_fn, ds.count_cat) else None
+
+        if overlay_aggregate.applies(element, agg_fn):
+            params = dict(
+                {p: v for p, v in self.get_param_values() if p != 'name'},
+                dynamic=False, **{p: v for p, v in self.p.items()
+                                  if p not in ('name', 'dynamic')})
+            return overlay_aggregate(element, **params)
+
+        if element._plot_id in self._precomputed:
+            x, y, data, glyph = self._precomputed[element._plot_id]
+        else:
+            x, y, data, glyph = self.get_agg_data(element, category)
+
+        if self.p.precompute:
+            self._precomputed[element._plot_id] = x, y, data, glyph
+        (x_range, y_range), (xs, ys), (width, height), (xtype, ytype) = self._get_sampling(element, x, y)
+        ((x0, x1), (y0, y1)), (xs, ys) = self._dt_transform(x_range, y_range, xs, ys, xtype, ytype)
+
+        params = self._get_agg_params(element, x, y, agg_fn, (x0, y0, x1, y1))
+
+        if x is None or y is None or width == 0 or height == 0:
+            return self._empty_agg(element, x, y, width, height, xs, ys, agg_fn, **params)
+        elif not len(data):
+            empty_val = 0 if isinstance(agg_fn, ds.count) else np.NaN
+            xarray = xr.DataArray(np.full((height, width), empty_val),
+                                  dims=[y.name, x.name], coords={x.name: xs, y.name: ys})
+            return self.p.element_type(xarray, **params)
+
+        cvs = ds.Canvas(plot_width=width, plot_height=height,
+                        x_range=x_range, y_range=y_range)
+
+        dfdata = PandasInterface.as_dframe(data)
+        agg = getattr(cvs, glyph)(dfdata, x.name, y.name, agg_fn)
+        if 'x_axis' in agg.coords and 'y_axis' in agg.coords:
+            agg = agg.rename({'x_axis': x, 'y_axis': y})
+        if xtype == 'datetime':
+            agg[x.name] = (agg[x.name]/1e3).astype('datetime64[us]')
+        if ytype == 'datetime':
+            agg[y.name] = (agg[y.name]/1e3).astype('datetime64[us]')
+
+        if agg.ndim == 2:
+            # Replacing x and y coordinates to avoid numerical precision issues
+            eldata = agg if ds_version > '0.5.0' else (xs, ys, agg.data)
+            return self.p.element_type(eldata, **params)
+        else:
+            layers = {}
+            for c in agg.coords[agg_fn.column].data:
+                cagg = agg.sel(**{agg_fn.column: c})
+                eldata = cagg if ds_version > '0.5.0' else (xs, ys, cagg.data)
+                layers[c] = self.p.element_type(eldata, **params)
+            return NdOverlay(layers, kdims=[data.get_dimension(agg_fn.column)])
+
+
+
+class overlay_aggregate(aggregate):
+    """
+    Optimized aggregation for NdOverlay objects by aggregating each
+    Element in an NdOverlay individually avoiding having to concatenate
+    items in the NdOverlay. Works by summing sum and count aggregates and
+    applying appropriate masking for NaN values. Mean aggregation
+    is also supported by dividing sum and count aggregates. count_cat
+    aggregates are grouped by the categorical dimension and a separate
+    aggregate for each category is generated.
+    """
+
+    @classmethod
+    def applies(cls, element, agg_fn):
+        return (isinstance(element, NdOverlay) and
+                ((isinstance(agg_fn, (ds.count, ds.sum, ds.mean)) and
+                  (agg_fn.column is None or agg_fn.column not in element.kdims)) or
+                 (isinstance(agg_fn, ds.count_cat) and agg_fn.column in element.kdims)))
+
+
+    def _process(self, element, key=None):
+        agg_fn = self._get_aggregator(element)
+        category = agg_fn.column if isinstance(agg_fn, ds.count_cat) else None
+
+        if not self.applies(element, agg_fn):
+            raise ValueError('overlay_aggregate only handles aggregation '
+                             'of NdOverlay types with count, sum or mean '
+                             'reduction.')
+
         # Compute overall bounds
         x, y = element.last.dimensions()[0:2]
-        info = self._get_sampling(element, x, y)
-        (x_range, y_range), (xs, ys), (width, height), (xtype, ytype) = info
-        if xtype == 'datetime':
-            x_range = tuple((np.array(x_range)/1e3).astype('datetime64[us]'))
-        if ytype == 'datetime':
-            y_range = tuple((np.array(y_range)/1e3).astype('datetime64[us]'))
+        (x_range, y_range), (xs, ys), (width, height), (xtype, ytype) = self._get_sampling(element, x, y)
+        ((x0, x1), (y0, y1)), _ = self._dt_transform(x_range, y_range, xs, ys, xtype, ytype)
         agg_params = dict({k: v for k, v in dict(self.get_param_values(), **self.p).items()
                            if k in aggregate.param},
-                          x_range=x_range, y_range=y_range)
-        bbox = BoundingBox(points=[(x_range[0], y_range[0]), (x_range[1], y_range[1])])
+                          x_range=(x0, x1), y_range=(y0, y1))
+        bbox = (x0, y0, x1, y1)
 
         # Optimize categorical counts by aggregating them individually
         if isinstance(agg_fn, ds.count_cat):
@@ -421,94 +534,6 @@ class aggregate(AggregationOperation):
             agg.data[column].values[mask] = np.NaN
 
         return agg.clone(bounds=bbox)
-
-
-    def _process(self, element, key=None):
-        agg_fn = self._get_aggregator(element)
-        category = agg_fn.column if isinstance(agg_fn, ds.count_cat) else None
-
-        if (isinstance(element, NdOverlay) and
-            ((isinstance(agg_fn, (ds.count, ds.sum, ds.mean)) and
-              (agg_fn.column is None or agg_fn.column not in element.kdims)) or
-             (isinstance(agg_fn, ds.count_cat) and agg_fn.column in element.kdims))):
-            return self._aggregate_ndoverlay(element, agg_fn)
-
-        if element._plot_id in self._precomputed:
-            x, y, data, glyph = self._precomputed[element._plot_id]
-        else:
-            x, y, data, glyph = self.get_agg_data(element, category)
-
-        if self.p.precompute:
-            self._precomputed[element._plot_id] = x, y, data, glyph
-        (x_range, y_range), (xs, ys), (width, height), (xtype, ytype) = self._get_sampling(element, x, y)
-
-        (x0, x1), (y0, y1) = x_range, y_range
-        if xtype == 'datetime':
-            x0, x1 = (np.array([x0, x1])/1e3).astype('datetime64[us]')
-            xs = (xs/1e3).astype('datetime64[us]')
-        if ytype == 'datetime':
-            y0, y1 = (np.array([y0, y1])/1e3).astype('datetime64[us]')
-            ys = (ys/1e3).astype('datetime64[us]')
-        bounds = (x0, y0, x1, y1)
-        params = dict(get_param_values(element), kdims=[x, y],
-                      datatype=['xarray'], bounds=bounds)
-
-        column = agg_fn.column if agg_fn else None
-        if column:
-            dims = [d for d in element.dimensions('ranges') if d == column]
-            if not dims:
-                raise ValueError("Aggregation column %s not found on %s element. "
-                                 "Ensure the aggregator references an existing "
-                                 "dimension." % (column,element))
-            name = '%s Count' % column if isinstance(agg_fn, ds.count_cat) else column
-            vdims = [dims[0](name)]
-        else:
-            vdims = Dimension('Count')
-        params['vdims'] = vdims
-
-        if x is None or y is None or width == 0 or height == 0:
-            x = x.name if x else 'x'
-            y = y.name if x else 'y'
-            xarray = xr.DataArray(np.full((height, width), np.NaN),
-                                  dims=[y, x], coords={x: xs, y: ys})
-            if width == 0:
-                params['xdensity'] = 1
-            if height == 0:
-                params['ydensity'] = 1
-            el = self.p.element_type(xarray, **params)
-            if isinstance(agg_fn, ds.count_cat):
-                vals = element.dimension_values(agg_fn.column, expanded=False)
-                dim = element.get_dimension(agg_fn.column)
-                return NdOverlay({v: el for v in vals}, dim)
-            return el
-        elif not len(data):
-            xarray = xr.DataArray(np.full((height, width), np.NaN),
-                                  dims=[y.name, x.name], coords={x.name: xs, y.name: ys})
-            return self.p.element_type(xarray, **params)
-
-        cvs = ds.Canvas(plot_width=width, plot_height=height,
-                        x_range=x_range, y_range=y_range)
-
-        dfdata = PandasInterface.as_dframe(data)
-        agg = getattr(cvs, glyph)(dfdata, x.name, y.name, agg_fn)
-        if 'x_axis' in agg.coords and 'y_axis' in agg.coords:
-            agg = agg.rename({'x_axis': x, 'y_axis': y})
-        if xtype == 'datetime':
-            agg[x.name] = (agg[x.name]/1e3).astype('datetime64[us]')
-        if ytype == 'datetime':
-            agg[y.name] = (agg[y.name]/1e3).astype('datetime64[us]')
-
-        if agg.ndim == 2:
-            # Replacing x and y coordinates to avoid numerical precision issues
-            eldata = agg if ds_version > '0.5.0' else (xs, ys, agg.data)
-            return self.p.element_type(eldata, **params)
-        else:
-            layers = {}
-            for c in agg.coords[column].data:
-                cagg = agg.sel(**{column: c})
-                eldata = cagg if ds_version > '0.5.0' else (xs, ys, cagg.data)
-                layers[c] = self.p.element_type(eldata, **dict(params, vdims=vdims))
-            return NdOverlay(layers, kdims=[data.get_dimension(column)])
 
 
 
@@ -618,15 +643,9 @@ class regrid(AggregationOperation):
                       np.linspace(ystart+yunit/2., yend-yunit/2., height))
 
         # Compute bounds (converting datetimes)
-        if xtype == 'datetime':
-            xstart, xend = (np.array([xstart, xend])/1e3).astype('datetime64[us]')
-            xs = (xs/1e3).astype('datetime64[us]')
-        if ytype == 'datetime':
-            ystart, yend = (np.array([ystart, yend])/1e3).astype('datetime64[us]')
-            ys = (ys/1e3).astype('datetime64[us]')
-        bbox = BoundingBox(points=[(xstart, ystart), (xend, yend)])
+        ((x0, x1), (y0, y1)), (xs, ys) = self._dt_transform(x_range, y_range, xs, ys, xtype, ytype)
 
-        params = dict(bounds=bbox)
+        params = dict(bounds=(x0, y0, x1, y1))
         if width == 0 or height == 0:
             if width == 0: params['xdensity'] = 1
             if height == 0: params['ydensity'] = 1
@@ -651,7 +670,7 @@ class regrid(AggregationOperation):
             regridded[vd] = rarray
         regridded = xr.Dataset(regridded)
 
-        return element.clone(regridded, bounds=bbox, datatype=['xarray']+element.datatype)
+        return element.clone(regridded, datatype=['xarray']+element.datatype, **params)
 
 
 

--- a/holoviews/tests/operation/testdatashader.py
+++ b/holoviews/tests/operation/testdatashader.py
@@ -4,7 +4,8 @@ from unittest import SkipTest
 
 import numpy as np
 from holoviews import (Dimension, Curve, Points, Image, Dataset, RGB, Path,
-                       Graph, TriMesh, QuadMesh, NdOverlay, Contours, Spikes)
+                       Graph, TriMesh, QuadMesh, NdOverlay, Contours, Spikes,
+                       Spread, Area)
 from holoviews.element.comparison import ComparisonTestCase
 
 try:
@@ -284,7 +285,78 @@ class DatashaderAggregateTests(ComparisonTestCase):
         expected = Image((xs, ys, arr), vdims='count')
         self.assertEqual(agg, expected)
 
-        
+    def test_area_aggregate_simple_count(self):
+        area = Area([1, 2, 1])
+        agg = rasterize(area, width=4, height=4, y_range=(0, 3), dynamic=False)
+        xs = [0.25, 0.75, 1.25, 1.75]
+        ys = [0.375, 1.125, 1.875, 2.625]
+        arr = np.array([
+            [1, 1, 1, 1],
+            [1, 1, 1, 1],
+            [0, 1, 1, 0],
+            [0, 0, 0, 0]
+        ])
+        expected = Image((xs, ys, arr), vdims='count')
+        self.assertEqual(agg, expected)
+
+    def test_area_aggregate_negative_count(self):
+        area = Area([-1, -2, -3])
+        agg = rasterize(area, width=4, height=4, y_range=(-3, 0), dynamic=False)
+        xs = [0.25, 0.75, 1.25, 1.75]
+        ys = [-2.625, -1.875, -1.125, -0.375]
+        arr = np.array([
+            [0, 0, 0, 1],
+            [0, 1, 1, 1],
+            [1, 1, 1, 1],
+            [1, 1, 1, 1]
+        ])
+        expected = Image((xs, ys, arr), vdims='count')
+        self.assertEqual(agg, expected)
+
+    def test_area_aggregate_crossover_count(self):
+        area = Area([-1, 2, 3])
+        agg = rasterize(area, width=4, height=4, y_range=(-3, 3), dynamic=False)
+        xs = [0.25, 0.75, 1.25, 1.75]
+        ys = [-2.25, -0.75, 0.75, 2.25]
+        arr = np.array([
+            [0, 0, 0, 0],
+            [1, 0, 0, 0],
+            [1, 1, 1, 1],
+            [0, 0, 1, 1]
+        ])
+        expected = Image((xs, ys, arr), vdims='count')
+        self.assertEqual(agg, expected)
+
+    def test_spread_aggregate_symmetric_count(self):
+        spread = Spread([(0, 1, 0.8), (1, 2, 0.3), (2, 3, 0.8)])
+        agg = rasterize(spread, width=4, height=4, dynamic=False)
+        xs = [0.25, 0.75, 1.25, 1.75]
+        ys = [0.65, 1.55, 2.45, 3.35]
+        arr = np.array([
+            [0, 0, 0, 0],
+            [1, 0, 0, 0],
+            [0, 1, 1, 0],
+            [0, 0, 0, 1]
+        ])
+        expected = Image((xs, ys, arr), vdims='count')
+        self.assertEqual(agg, expected)
+
+    def test_spread_aggregate_assymmetric_count(self):
+        spread = Spread([(0, 1, 0.4, 0.8), (1, 2, 0.8, 0.4), (2, 3, 0.5, 1)],
+                        vdims=['y', 'pos', 'neg'])
+        agg = rasterize(spread, width=4, height=4, dynamic=False)
+        xs = [0.25, 0.75, 1.25, 1.75]
+        ys = [0.6125, 1.4375, 2.2625, 3.0875]
+        arr = np.array([
+            [0, 0, 0, 0],
+            [1, 0, 0, 0],
+            [0, 1, 1, 0],
+            [0, 0, 1, 1]
+        ])
+        expected = Image((xs, ys, arr), vdims='count')
+        self.assertEqual(agg, expected)
+
+
 
 class DatashaderShadeTests(ComparisonTestCase):
 


### PR DESCRIPTION
Some refactoring of datashader operations to make it easier to implement new operations. Additionally adds an operation to aggregate ``Spikes``:

Handles simple spikes:

![uniform_spikes_simple](https://user-images.githubusercontent.com/1550771/63224665-bd4b6b80-c1c7-11e9-8ec3-10aeec86f81e.gif)

Handles datetimes:

![date_spikes_simple](https://user-images.githubusercontent.com/1550771/63224666-c1778900-c1c7-11e9-9654-f075acd3eaa0.gif)

Handles Spikes with vdims:

![date_spikes_with_vdim](https://user-images.githubusercontent.com/1550771/63224668-c3414c80-c1c7-11e9-9ba8-29bcf88a336e.gif)

- [x] Add tests
- [x] Add Spikes aggregator with and with values and positive and negative heights
- [x] Add Area aggregator
- [x] Add Spread aggregator
- [x] Add docs

Cc: @jlstevens @jbednar 