### PR TITLE
Add LabelledData.dataset property

### DIFF
--- a/holoviews/core/data/__init__.py
+++ b/holoviews/core/data/__init__.py
@@ -854,8 +854,18 @@ class Dataset(Element):
         if 'datatype' not in overrides:
             datatypes = [self.interface.datatype] + self.datatype
             overrides['datatype'] = list(util.unique_iterator(datatypes))
-        return super(Dataset, self).clone(data, shared_data, new_type, *args, **overrides)
 
+        if 'dataset' in overrides:
+            dataset = overrides.pop('dataset')
+        else:
+            dataset = self.dataset
+
+        new_dataset = super(Dataset, self).clone(data, shared_data, new_type, *args, **overrides)
+
+        if dataset:
+            new_dataset._dataset = dataset.clone(data=new_dataset.data, dataset=None)
+
+        return new_dataset
 
     @property
     def iloc(self):

--- a/holoviews/core/data/__init__.py
+++ b/holoviews/core/data/__init__.py
@@ -14,7 +14,7 @@ from ..dimension import Dimension, process_dimensions
 from ..element import Element
 from ..ndmapping import OrderedDict
 from ..spaces import HoloMap, DynamicMap
-from .interface import Interface, iloc, ndloc
+from .interface import Interface, iloc, ndloc, DataError
 from .array import ArrayInterface
 from .dictionary import DictInterface
 from .grid import GridInterface
@@ -862,8 +862,13 @@ class Dataset(Element):
 
         new_dataset = super(Dataset, self).clone(data, shared_data, new_type, *args, **overrides)
 
-        if dataset:
-            new_dataset._dataset = dataset.clone(data=new_dataset.data, dataset=None)
+        if dataset is not None:
+            try:
+                new_dataset._dataset = dataset.clone(data=new_dataset.data, dataset=None)
+            except DataError:
+                # New dataset doesn't have the necessary dimensions to
+                # propagate dataset. Do nothing
+                pass
 
         return new_dataset
 

--- a/holoviews/core/data/__init__.py
+++ b/holoviews/core/data/__init__.py
@@ -153,6 +153,8 @@ class DataConversion(object):
             params['group'] = selected.group
         params.update(kwargs)
         if len(kdims) == selected.ndims or not groupby:
+            # Propagate dataset
+            params['dataset'] = self._element.dataset
             element = new_type(selected, **params)
             return element.sort() if sort else element
         group = selected.groupby(groupby, container_type=HoloMap,

--- a/holoviews/core/data/dask.py
+++ b/holoviews/core/data/dask.py
@@ -164,6 +164,9 @@ class DaskInterface(PandasInterface):
                                 kdims=element_dims)
         group_kwargs.update(kwargs)
 
+        # Propagate dataset
+        group_kwargs['dataset'] = dataset.dataset
+
         data = []
         group_by = [d.name for d in index_dims]
         groupby = dataset.data.groupby(group_by)

--- a/holoviews/core/data/interface.py
+++ b/holoviews/core/data/interface.py
@@ -63,7 +63,7 @@ class iloc(object):
         rows, cols = index
         if rows is Ellipsis:
             rows = slice(None)
-        data = self.dataset.interface.iloc(self.dataset, (rows, cols))
+        data = self.dataset.interface.iloc(self.dataset.dataset, (rows, cols))
         kdims = self.dataset.kdims
         vdims = self.dataset.vdims
         if np.isscalar(data):

--- a/holoviews/core/data/pandas.py
+++ b/holoviews/core/data/pandas.py
@@ -190,6 +190,9 @@ class PandasInterface(Interface):
                                 kdims=element_dims)
         group_kwargs.update(kwargs)
 
+        # Propagate dataset
+        group_kwargs['dataset'] = dataset.dataset
+
         group_by = [d.name for d in index_dims]
         data = [(k, group_type(v, **group_kwargs)) for k, v in
                 dataset.data.groupby(group_by, sort=False)]

--- a/holoviews/core/dimension.py
+++ b/holoviews/core/dimension.py
@@ -505,7 +505,13 @@ class LabelledData(param.Parameterized):
         if self._dataset is None:
             # Create a default Dataset to wrap input data
             try:
-                dataset = Dataset(self.data)
+                kdims = list(params.get('kdims', []))
+                vdims = list(params.get('vdims', []))
+                dims = kdims + vdims
+                dataset = Dataset(
+                    self.data,
+                    kdims=dims if dims else None
+                )
                 if len(dataset.dimensions()) == 0:
                     # No dimensions could be auto-detected in data
                     raise DataError("No dimensions detected")

--- a/holoviews/core/dimension.py
+++ b/holoviews/core/dimension.py
@@ -490,8 +490,13 @@ class LabelledData(param.Parameterized):
         self.data = data
 
         # Handle initializing the dataset property.
+        input_dataset = params.pop('dataset', None)
         if type(self) is Dataset:
             self._dataset = self
+        elif input_dataset is not None:
+            # Clone dimension info from input dataset with reference to new
+            # data. This way we keep the metadata for all of the dimensions.
+            self._dataset = input_dataset.clone(data=self.data)
         else:
             # Create a default Dataset to wrap input data
             self._dataset = Dataset(self.data)

--- a/holoviews/core/dimension.py
+++ b/holoviews/core/dimension.py
@@ -505,7 +505,11 @@ class LabelledData(param.Parameterized):
         if self._dataset is None:
             # Create a default Dataset to wrap input data
             try:
-                self._dataset = Dataset(self.data)
+                dataset = Dataset(self.data)
+                if len(dataset.dimensions()) == 0:
+                    # No dimensions could be auto-detected in data
+                    raise DataError("No dimensions detected")
+                self._dataset = dataset
             except DataError:
                 # Data not supported by any storage backend. leave _dataset as
                 # None

--- a/holoviews/core/dimension.py
+++ b/holoviews/core/dimension.py
@@ -490,21 +490,26 @@ class LabelledData(param.Parameterized):
         self.data = data
 
         # Handle initializing the dataset property.
+        self._dataset = None
         input_dataset = params.pop('dataset', None)
         if type(self) is Dataset:
             self._dataset = self
         elif input_dataset is not None:
             # Clone dimension info from input dataset with reference to new
             # data. This way we keep the metadata for all of the dimensions.
-            self._dataset = input_dataset.clone(data=self.data)
-        else:
+            try:
+                self._dataset = input_dataset.clone(data=self.data)
+            except DataError:
+                # Dataset not compatible with input data
+                pass
+        if self._dataset is None:
             # Create a default Dataset to wrap input data
             try:
                 self._dataset = Dataset(self.data)
             except DataError:
                 # Data not supported by any storage backend. leave _dataset as
                 # None
-                self._dataset = None
+                pass
 
         self._id = None
         self.id = id

--- a/holoviews/core/dimension.py
+++ b/holoviews/core/dimension.py
@@ -486,7 +486,7 @@ class LabelledData(param.Parameterized):
         This class also has an id instance attribute, which
         may be set to associate some custom options with the object.
         """
-        from . import Dataset
+        from . import Dataset, DataError
         self.data = data
 
         # Handle initializing the dataset property.
@@ -499,7 +499,12 @@ class LabelledData(param.Parameterized):
             self._dataset = input_dataset.clone(data=self.data)
         else:
             # Create a default Dataset to wrap input data
-            self._dataset = Dataset(self.data)
+            try:
+                self._dataset = Dataset(self.data)
+            except DataError:
+                # Data not supported by any storage backend. leave _dataset as
+                # None
+                self._dataset = None
 
         self._id = None
         self.id = id

--- a/holoviews/core/dimension.py
+++ b/holoviews/core/dimension.py
@@ -486,7 +486,16 @@ class LabelledData(param.Parameterized):
         This class also has an id instance attribute, which
         may be set to associate some custom options with the object.
         """
+        from . import Dataset
         self.data = data
+
+        # Handle initializing the dataset property.
+        if type(self) is Dataset:
+            self._dataset = self
+        else:
+            # Create a default Dataset to wrap input data
+            self._dataset = Dataset(self.data)
+
         self._id = None
         self.id = id
         self._plot_id = plot_id or util.builtins.id(self)
@@ -507,6 +516,10 @@ class LabelledData(param.Parameterized):
         elif not util.label_sanitizer.allowable(self.label):
             raise ValueError("Supplied label %r contains invalid characters." %
                              self.label)
+
+    @property
+    def dataset(self):
+        return self._dataset
 
     @property
     def id(self):

--- a/holoviews/element/chart.py
+++ b/holoviews/element/chart.py
@@ -217,6 +217,22 @@ class Histogram(Chart):
 
         return new_element
 
+    def select(self, selection_specs=None, **selection):
+        selected = super(Histogram, self).select(
+            selection_specs=selection_specs, **selection
+        )
+
+        if not np.isscalar(selected) and not np.equal(selected.data, self.data):
+            # Selection changed histogram bins, so update dataset
+            selection = {
+                dim: sel for dim, sel in selection.items()
+                if dim in self.dimensions()+['selection_mask']
+            }
+
+            selected._dataset = self.dataset.select(**selection)
+
+        return selected
+
     def __setstate__(self, state):
         """
         Ensures old-style Histogram types without an interface can be unpickled.

--- a/holoviews/element/chart.py
+++ b/holoviews/element/chart.py
@@ -222,7 +222,7 @@ class Histogram(Chart):
             selection_specs=selection_specs, **selection
         )
 
-        if not np.isscalar(selected) and not np.equal(selected.data, self.data):
+        if not np.isscalar(selected) and not np.array_equal(selected.data, self.data):
             # Selection changed histogram bins, so update dataset
             selection = {
                 dim: sel for dim, sel in selection.items()

--- a/holoviews/element/chart.py
+++ b/holoviews/element/chart.py
@@ -181,8 +181,16 @@ class Histogram(Chart):
             data = (edges, data)
         elif isinstance(data, tuple) and len(data) == 2 and len(data[0])+1 == len(data[1]):
             data = data[::-1]
+
+        dataset = params.pop("dataset", None)
         super(Histogram, self).__init__(data, **params)
 
+        if dataset:
+            # Histogram is a special case in which we keep the data from the
+            # input dataset rather than replace it with the element data.
+            # This is so that dataset contains the data needed to reconstruct
+            # the element.
+            self._dataset = dataset.clone()
 
     def __setstate__(self, state):
         """

--- a/holoviews/element/chart.py
+++ b/holoviews/element/chart.py
@@ -229,7 +229,8 @@ class Histogram(Chart):
                 if dim in self.dimensions()+['selection_mask']
             }
 
-            selected._dataset = self.dataset.select(**selection)
+            if selected._dataset is not None:
+                selected._dataset = self.dataset.select(**selection)
 
         return selected
 

--- a/holoviews/element/chart.py
+++ b/holoviews/element/chart.py
@@ -192,6 +192,31 @@ class Histogram(Chart):
             # the element.
             self._dataset = dataset.clone()
 
+    def clone(self, data=None, shared_data=True, new_type=None, *args, **overrides):
+        if 'dataset' in overrides:
+            dataset = overrides.pop('dataset', None)
+        else:
+            dataset = self.dataset
+
+        overrides["dataset"] = None
+
+        new_element = super(Histogram, self).clone(
+            data=data,
+            shared_data=shared_data,
+            new_type=new_type,
+            *args,
+            **overrides
+        )
+
+        if dataset:
+            # Histogram is a special case in which we keep the data from the
+            # input dataset rather than replace it with the element data.
+            # This is so that dataset contains the data needed to reconstruct
+            # the element.
+            new_element._dataset = dataset.clone()
+
+        return new_element
+
     def __setstate__(self, state):
         """
         Ensures old-style Histogram types without an interface can be unpickled.

--- a/holoviews/element/stats.py
+++ b/holoviews/element/stats.py
@@ -21,7 +21,8 @@ class StatisticsElement(Dataset, Element2D):
     _auto_indexable_1d = False
 
     def __init__(self, data, kdims=None, vdims=None, **params):
-        if isinstance(data, Element):
+        if (isinstance(data, Element) and
+                data.interface.datatype != "dataframe"):
             params.update(get_param_values(data))
             kdims = kdims or data.dimensions()[:len(self.kdims)]
             data = tuple(data.dimension_values(d) for d in kdims)

--- a/holoviews/operation/element.py
+++ b/holoviews/operation/element.py
@@ -656,7 +656,7 @@ class histogram(Operation):
             if self.p.normed in (True, 'integral'):
                 hist *= edges[1]-edges[0]
         return Histogram((edges, hist), kdims=[element.get_dimension(selected_dim)],
-                         label=element.label, **params)
+                         label=element.label, dataset=element.dataset, **params)
 
 
 class decimate(Operation):

--- a/holoviews/tests/core/testdatasetproperty.py
+++ b/holoviews/tests/core/testdatasetproperty.py
@@ -1,6 +1,6 @@
 from holoviews.element.comparison import ComparisonTestCase
 import pandas as pd
-from holoviews import Dataset, Curve, Dimension, Scatter, Histogram
+from holoviews import Dataset, Curve, Dimension, Scatter
 import dask.dataframe as dd
 
 class DatasetPropertyTestCase(ComparisonTestCase):

--- a/holoviews/tests/core/testdatasetproperty.py
+++ b/holoviews/tests/core/testdatasetproperty.py
@@ -1,0 +1,33 @@
+from holoviews.element.comparison import ComparisonTestCase
+import pandas as pd
+from holoviews import Dataset, Curve, Dimension, Scatter, Histogram
+
+
+class DatasetPropertyTestCase(ComparisonTestCase):
+
+    def setUp(self):
+        self.df = pd.DataFrame({
+            'a': [1, 1, 3, 3, 2, 2, 0, 0],
+            'b': [10, 20, 30, 40, 10, 20, 30, 40],
+            'c': ['A', 'A', 'B', 'B', 'C', 'C', 'D', 'D'],
+            'd': [-1, -2, -3, -4, -5, -6, -7, -8]
+        })
+
+        self.ds = Dataset(
+            self.df,
+            kdims=[
+                Dimension('a', label="The a Column"),
+                Dimension('b', label="The b Column"),
+                Dimension('c', label="The c Column"),
+                Dimension('d', label="The d Column"),
+            ]
+        )
+
+
+class ConstructorTestCase(DatasetPropertyTestCase):
+    def test_constructors(self):
+        expected = Dataset(self.df)
+        self.assertIs(expected, expected.dataset)
+
+        element = Curve(self.df)
+        self.assertEqual(element.dataset, expected)

--- a/holoviews/tests/core/testdatasetproperty.py
+++ b/holoviews/tests/core/testdatasetproperty.py
@@ -31,3 +31,12 @@ class ConstructorTestCase(DatasetPropertyTestCase):
 
         element = Curve(self.df)
         self.assertEqual(element.dataset, expected)
+
+
+class ToTestCase(DatasetPropertyTestCase):
+    def test_to_element(self):
+        curve = self.ds.to(Curve, 'a', 'b', groupby=[])
+        self.assertEqual(curve.dataset, self.ds)
+
+        scatter = curve.to(Scatter)
+        self.assertEqual(scatter.dataset, self.ds)

--- a/holoviews/tests/core/testdatasetproperty.py
+++ b/holoviews/tests/core/testdatasetproperty.py
@@ -128,3 +128,20 @@ class IlocTestCase(DatasetPropertyTestCase):
             curve.iloc[[0, 2]].dataset,
             expected
         )
+
+
+class SelectTestCase(DatasetPropertyTestCase):
+    def test_select_dataset(self):
+        # Dataset
+        self.assertEqual(
+            self.ds.select(b=10).dataset,
+            self.ds.select(b=10)
+        )
+
+    def test_select_curve(self):
+        # Curve
+        self.assertEqual(
+            self.ds.to.curve('a', 'b', groupby=[]).select(b=10).dataset,
+            self.ds.select(b=10)
+        )
+

--- a/holoviews/tests/core/testdatasetproperty.py
+++ b/holoviews/tests/core/testdatasetproperty.py
@@ -157,3 +157,23 @@ class HistogramTestCase(DatasetPropertyTestCase):
 
     def test_clone(self):
         self.assertEqual(self.hist.clone().dataset, self.ds)
+
+    def test_select_single(self):
+        sub_hist = self.hist.select(a=(1, None))
+        self.assertEqual(sub_hist.dataset, self.ds.select(a=(1, None)))
+
+    def test_select_multi(self):
+        # Add second selection on b. b is a dimension in hist.dataset but
+        # not in hist.  Make sure that we only apply the a selection (and not
+        # the b selection) to the .dataset property
+        sub_hist = self.hist.select(a=(1, None), b=100)
+
+        self.assertNotEqual(
+            sub_hist.dataset,
+            self.ds.select(a=(1, None), b=100)
+        )
+
+        self.assertEqual(
+            sub_hist.dataset,
+            self.ds.select(a=(1, None))
+        )

--- a/holoviews/tests/core/testdatasetproperty.py
+++ b/holoviews/tests/core/testdatasetproperty.py
@@ -145,3 +145,12 @@ class SelectTestCase(DatasetPropertyTestCase):
             self.ds.select(b=10)
         )
 
+
+class HistogramTestCase(DatasetPropertyTestCase):
+
+    def setUp(self):
+        super(HistogramTestCase, self).setUp()
+        self.hist = self.ds.hist('a', adjoin=False, normed=False)
+
+    def test_construction(self):
+        self.assertEqual(self.hist.dataset, self.ds)

--- a/holoviews/tests/core/testdatasetproperty.py
+++ b/holoviews/tests/core/testdatasetproperty.py
@@ -154,3 +154,6 @@ class HistogramTestCase(DatasetPropertyTestCase):
 
     def test_construction(self):
         self.assertEqual(self.hist.dataset, self.ds)
+
+    def test_clone(self):
+        self.assertEqual(self.hist.clone().dataset, self.ds)

--- a/holoviews/tests/core/testdatasetproperty.py
+++ b/holoviews/tests/core/testdatasetproperty.py
@@ -177,3 +177,7 @@ class HistogramTestCase(DatasetPropertyTestCase):
             sub_hist.dataset,
             self.ds.select(a=(1, None))
         )
+
+    def test_hist_to_curve(self):
+        # No exception thrown
+        self.hist.to.curve()

--- a/holoviews/tests/core/testdatasetproperty.py
+++ b/holoviews/tests/core/testdatasetproperty.py
@@ -1,6 +1,6 @@
 from holoviews.element.comparison import ComparisonTestCase
 import pandas as pd
-from holoviews import Dataset, Curve, Dimension, Scatter
+from holoviews import Dataset, Curve, Dimension, Scatter, Distribution
 import dask.dataframe as dd
 
 class DatasetPropertyTestCase(ComparisonTestCase):
@@ -183,3 +183,13 @@ class HistogramTestCase(DatasetPropertyTestCase):
     def test_hist_to_curve(self):
         # No exception thrown
         self.hist.to.curve()
+
+
+class DistributionTestCase(DatasetPropertyTestCase):
+
+    def setUp(self):
+        super(DistributionTestCase, self).setUp()
+        self.distribution = self.ds.to(Distribution, kdims='a', groupby=[])
+
+    def test_distribution_dataset(self):
+        self.assertEqual(self.distribution.dataset, self.ds)

--- a/holoviews/tests/core/testdatasetproperty.py
+++ b/holoviews/tests/core/testdatasetproperty.py
@@ -107,3 +107,24 @@ class ReindexTestCase(DatasetPropertyTestCase):
         curve_ba = curve_ab.reindex(kdims='b', vdims='a')
         self.assertEqual(curve_ab.dataset, self.ds)
         self.assertEqual(curve_ba.dataset, self.ds)
+
+
+class IlocTestCase(DatasetPropertyTestCase):
+    def test_iloc_dataset(self):
+        expected = self.ds.iloc[[0, 2]]
+
+        # Dataset
+        self.assertEqual(
+            self.ds.clone().iloc[[0, 2]].dataset,
+            expected
+        )
+
+    def test_iloc_curve(self):
+        expected = self.ds.iloc[[0, 2]]
+
+        # Curve
+        curve = self.ds.to.curve('a', 'b', groupby=[])
+        self.assertEqual(
+            curve.iloc[[0, 2]].dataset,
+            expected
+        )

--- a/holoviews/tests/core/testdatasetproperty.py
+++ b/holoviews/tests/core/testdatasetproperty.py
@@ -25,11 +25,13 @@ class DatasetPropertyTestCase(ComparisonTestCase):
 
 
 class ConstructorTestCase(DatasetPropertyTestCase):
-    def test_constructors(self):
+    def test_constructors_dataset(self):
         expected = Dataset(self.df)
         self.assertIs(expected, expected.dataset)
 
+    def test_constructor_curve(self):
         element = Curve(self.df)
+        expected = Dataset(self.df)
         self.assertEqual(element.dataset, expected)
 
 

--- a/holoviews/tests/core/testdatasetproperty.py
+++ b/holoviews/tests/core/testdatasetproperty.py
@@ -40,3 +40,39 @@ class ToTestCase(DatasetPropertyTestCase):
 
         scatter = curve.to(Scatter)
         self.assertEqual(scatter.dataset, self.ds)
+
+
+class CloneTestCase(DatasetPropertyTestCase):
+    def test_clone(self):
+        # Dataset
+        self.assertEqual(self.ds.clone().dataset, self.ds)
+
+        # Curve
+        self.assertEqual(
+            self.ds.to.curve('a', 'b', groupby=[]).clone().dataset,
+            self.ds
+        )
+
+
+class ReindexTestCase(DatasetPropertyTestCase):
+    def test_reindex_dataset(self):
+        ds_ab = self.ds.reindex(kdims=['a'], vdims=['b'])
+        self.assertEqual(ds_ab.dataset, self.ds)
+
+    def test_double_reindex_dataset(self):
+        ds_abc = self.ds.reindex(kdims=['a'], vdims=['b', 'c'])
+        ds_ab = ds_abc.reindex(kdims=['a'], vdims=['b'])
+        self.assertEqual(ds_ab.dataset, self.ds)
+
+    def test_reindex_curve(self):
+        curve_ab = self.ds.to(Curve, 'a', 'b', groupby=[])
+        curve_ba = curve_ab.reindex(kdims='b', vdims='a')
+        self.assertEqual(curve_ab.dataset, self.ds)
+        self.assertEqual(curve_ba.dataset, self.ds)
+
+    def test_double_reindex_curve(self):
+        curve_abc = self.ds.to(Curve, 'a', ['b', 'c'], groupby=[])
+        curve_ab = curve_abc.reindex(kdims='a', vdims='b')
+        curve_ba = curve_ab.reindex(kdims='b', vdims='a')
+        self.assertEqual(curve_ab.dataset, self.ds)
+        self.assertEqual(curve_ba.dataset, self.ds)


### PR DESCRIPTION
## Motivation
This PR was motivated by the automatic selection proposal in https://github.com/pyviz/holoviews/issues/3842.  The goal that this PR addresses is to provide a way for  elements to maintain a reference to all of the dimensions in the dataset that they were created from.

I believe this approach accomplishes this goal in a fairly general way, and so I expect it to be useful for other purposes as well.

@jlstevens @philippjfr 

## Overview
A new `.dataset` property is added to the `LabelledData` class (the class that defines the `.data` property).  This property should always be either `None` or an instance of a `Dataset` class (not an instance of a subclass of `Dataset`).

## Rules for the dataset property
The rules that the new dataset property follows are best described by the tests in the new test file at `holoviews/tests/core/testdatasetproperty.py`.  Here are some notes:

 - The `dataset` property generally references the same `.data` object as the element and it generally includes dimensions for all of the columns in `.data`.
 - When an element is created directly from the constructor, the `dataset` property is simply a new `Dataset` object wrapping the element's `data`.
- When elements are created from other elements, the goal is to propagate the `dataset` property from the initial element. Some examples where the dataset property propagates:
    - `element.to`
    - `element.clone`
    - `element.reindex`
    - `element.iloc`
    - `element.select`
    -  `Element(element)` (passing one element to an element constructor)

## Special rules for `Histogram`
This PR includes special handling for the `Histogram` element.  This element stores, as its `data` property, the bin edges and frequencies/counts of the histogram.  It does not retain a reference back to any dataset that may have been used to create it.  In this way, it is a bit inconsistent with other related elements, like `Distribution`, which do store the raw data in the `.data` property.

For the `Histogram` element, the `dataset` property stores a reference to the `Dataset` that it was created from (or `None` if the `Histogram` is constructed with predetermined edges and frequencies).  This makes it possible to recreate the histogram from the `dataset` property, or to create a histogram with only a subset of the original data (This is the linked data selection usecase).

If we decided to someday change `Histogram` to work like `Distribution`, then `Histogram` would no longer be a special case.

## TODO
 - [x] Flow dataset through `Distribution` and `Bivariate` elements








