### PR TITLE
Add dim-expression support in Dataset.select 

### DIFF
--- a/holoviews/core/data/__init__.py
+++ b/holoviews/core/data/__init__.py
@@ -453,7 +453,7 @@ class Dataset(Element):
                object.
         """
         slices = util.process_ellipses(self, slices, vdim_selection=True)
-        if isinstance(slices, np.ndarray) and slices.dtype.kind == 'b':
+        if getattr(getattr(slices, 'dtype', None), 'kind', None) == 'b':
             if not len(slices) == len(self):
                 raise IndexError("Boolean index must match length of sliced object")
             return self.clone(self.select(selection_mask=slices))

--- a/holoviews/core/data/__init__.py
+++ b/holoviews/core/data/__init__.py
@@ -335,7 +335,7 @@ class Dataset(Element):
         return self.clone(data, **dimensions)
 
 
-    def select(self, selection_specs=None, selection_expr=None, **selection):
+    def select(self, selection_expr=None, selection_specs=None, **selection):
         """Applies selection by dimension name
 
         Applies a selection along the dimensions of the object using
@@ -366,12 +366,12 @@ class Dataset(Element):
             ds.select(selection_expr=dim('x') % 2 == 0)
 
         Args:
+            selection_expr: holoviews.dim predicate expression
+                specifying selection.
             selection_specs: List of specs to match on
                 A list of types, functions, or type[.group][.label]
                 strings specifying which objects to apply the
                 selection on.
-            selection_expr: holoviews.dim predicate expression
-                specifying selection.
             **selection: Dictionary declaring selections by dimension
                 Selections can be scalar values, tuple ranges, lists
                 of discrete values and boolean arrays
@@ -380,10 +380,17 @@ class Dataset(Element):
             Returns an Dimensioned object containing the selected data
             or a scalar if a single value was selected
         """
+        from ...util.transform import dim
+        if selection_expr is not None and not isinstance(selection_expr, dim):
+            raise ValueError("""\
+The first positional argument to the Dataset.select method is expected to be a
+holoviews.util.transform.dim expression. Use the selection_specs keyword
+argument to specify a selection specification""")
+
         if selection_specs is not None and not isinstance(selection_specs, (list, tuple)):
             selection_specs = [selection_specs]
-        selection = {dim: sel for dim, sel in selection.items()
-                     if dim in self.dimensions()+['selection_mask']}
+        selection = {dim_name: sel for dim_name, sel in selection.items()
+                     if dim_name in self.dimensions()+['selection_mask']}
         if (selection_specs and not any(self.matches(sp) for sp in selection_specs)
                 or (not selection and not selection_expr)):
             return self

--- a/holoviews/core/data/array.py
+++ b/holoviews/core/data/array.py
@@ -123,7 +123,9 @@ class ArrayInterface(Interface):
 
 
     @classmethod
-    def values(cls, dataset, dim, expanded=True, flat=True, compute=True):
+    def values(
+            cls, dataset, dim, expanded=True, flat=True, compute=True, keep_index=False
+    ):
         data = dataset.data
         dim_idx = dataset.get_dimension_index(dim)
         if data.ndim == 1:

--- a/holoviews/core/data/dask.py
+++ b/holoviews/core/data/dask.py
@@ -90,12 +90,23 @@ class DaskInterface(PandasInterface):
         return dataset.data
 
     @classmethod
-    def values(cls, dataset, dim, expanded=True, flat=True, compute=True):
+    def values(
+            cls,
+            dataset,
+            dim,
+            expanded=True,
+            flat=True,
+            compute=True,
+            keep_index=False,
+    ):
         dim = dataset.get_dimension(dim)
         data = dataset.data[dim.name]
         if not expanded:
             data = data.unique()
-        return data.compute().values if compute else data.values
+        if keep_index:
+            return data.compute() if compute else data
+        else:
+            return data.compute().values if compute else data.values
 
     @classmethod
     def select_mask(cls, dataset, selection):

--- a/holoviews/core/data/dictionary.py
+++ b/holoviews/core/data/dictionary.py
@@ -246,7 +246,9 @@ class DictInterface(Interface):
 
 
     @classmethod
-    def values(cls, dataset, dim, expanded=True, flat=True, compute=True):
+    def values(
+            cls, dataset, dim, expanded=True, flat=True, compute=True, keep_index=False
+    ):
         dim = dataset.get_dimension(dim).name
         values = dataset.data.get(dim)
         if isscalar(values):

--- a/holoviews/core/data/grid.py
+++ b/holoviews/core/data/grid.py
@@ -338,7 +338,9 @@ class GridInterface(DictInterface):
 
 
     @classmethod
-    def values(cls, dataset, dim, expanded=True, flat=True, compute=True):
+    def values(
+            cls, dataset, dim, expanded=True, flat=True, compute=True, keep_index=False
+    ):
         dim = dataset.get_dimension(dim, strict=True)
         if dim in dataset.vdims or dataset.data[dim.name].ndim > 1:
             data = dataset.data[dim.name]

--- a/holoviews/core/data/image.py
+++ b/holoviews/core/data/image.py
@@ -156,7 +156,9 @@ class ImageInterface(GridInterface):
 
 
     @classmethod
-    def values(cls, dataset, dim, expanded=True, flat=True, compute=True):
+    def values(
+            cls, dataset, dim, expanded=True, flat=True, compute=True, keep_index=False
+    ):
         """
         The set of samples available along a particular dimension.
         """

--- a/holoviews/core/data/multipath.py
+++ b/holoviews/core/data/multipath.py
@@ -281,7 +281,15 @@ class MultiInterface(Interface):
         return new_data
 
     @classmethod
-    def values(cls, dataset, dimension, expanded=True, flat=True, compute=True):
+    def values(
+            cls,
+            dataset,
+            dimension,
+            expanded=True,
+            flat=True,
+            compute=True,
+            keep_index=False,
+    ):
         """
         Returns a single concatenated array of all subpaths separated
         by NaN values. If expanded keyword is False an array of arrays
@@ -293,7 +301,9 @@ class MultiInterface(Interface):
         ds = cls._inner_dataset_template(dataset)
         for d in dataset.data:
             ds.data = d
-            dvals = ds.interface.values(ds, dimension, expanded, flat, compute)
+            dvals = ds.interface.values(
+                ds, dimension, expanded, flat, compute, keep_index
+            )
             if not len(dvals):
                 continue
             elif expanded:

--- a/holoviews/core/data/pandas.py
+++ b/holoviews/core/data/pandas.py
@@ -266,8 +266,12 @@ class PandasInterface(Interface):
         df = dataset.data
         if selection_mask is None:
             selection_mask = cls.select_mask(dataset, selection)
+
         indexed = cls.indexed(dataset, selection)
-        df = df.iloc[selection_mask]
+        if isinstance(selection_mask, pd.Series):
+            df = df[selection_mask]
+        else:
+            df = df.iloc[selection_mask]
         if indexed and len(df) == 1 and len(dataset.vdims) == 1:
             return df[dataset.vdims[0].name].iloc[0]
         return df

--- a/holoviews/core/data/pandas.py
+++ b/holoviews/core/data/pandas.py
@@ -274,12 +274,21 @@ class PandasInterface(Interface):
 
 
     @classmethod
-    def values(cls, dataset, dim, expanded=True, flat=True, compute=True):
+    def values(
+            cls,
+            dataset,
+            dim,
+            expanded=True,
+            flat=True,
+            compute=True,
+            keep_index=False,
+    ):
         dim = dataset.get_dimension(dim, strict=True)
         data = dataset.data[dim.name]
         if not expanded:
             return data.unique()
-        return data.values
+
+        return data if keep_index else data.values
 
 
     @classmethod

--- a/holoviews/core/data/xarray.py
+++ b/holoviews/core/data/xarray.py
@@ -303,7 +303,7 @@ class XArrayInterface(GridInterface):
 
 
     @classmethod
-    def values(cls, dataset, dim, expanded=True, flat=True, compute=True):
+    def values(cls, dataset, dim, expanded=True, flat=True, compute=True, keep_index=False):
         dim = dataset.get_dimension(dim, strict=True)
         data = dataset.data[dim.name].data
         irregular = cls.irregular(dataset, dim) if dim in dataset.kdims else False

--- a/holoviews/core/dimension.py
+++ b/holoviews/core/dimension.py
@@ -1109,14 +1109,14 @@ class Dimensioned(LabelledData):
             # Apply the selection on the selected object of a different type
             dimensions = selection.dimensions() + ['value']
             if any(kw in dimensions for kw in kwargs):
-                selection = selection.select(selection_specs, **kwargs)
+                selection = selection.select(selection_specs=selection_specs, **kwargs)
         elif isinstance(selection, Dimensioned) and selection._deep_indexable:
             # Apply the deep selection on each item in local selection
             items = []
             for k, v in selection.items():
                 dimensions = v.dimensions() + ['value']
                 if any(kw in dimensions for kw in kwargs):
-                    items.append((k, v.select(selection_specs, **kwargs)))
+                    items.append((k, v.select(selection_specs=selection_specs, **kwargs)))
                 else:
                     items.append((k, v))
             selection = selection.clone(items)

--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -1371,7 +1371,7 @@ class DynamicMap(HoloMap):
         """
         if selection_specs is not None and not isinstance(selection_specs, (list, tuple)):
             selection_specs = [selection_specs]
-        selection = super(DynamicMap, self).select(selection_specs, **kwargs)
+        selection = super(DynamicMap, self).select(selection_specs=selection_specs, **kwargs)
         def dynamic_select(obj, **dynkwargs):
             if selection_specs is not None:
                 matches = any(obj.matches(spec) for spec in selection_specs)

--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -505,7 +505,7 @@ def process_ellipses(obj, key, vdim_selection=False):
     will be exactly one longer than the number of kdims). Note: this
     flag should not be used for composite types.
     """
-    if isinstance(key, np.ndarray) and key.dtype.kind == 'b':
+    if getattr(getattr(key, 'dtype', None), 'kind', None) == 'b':
         return key
     wrapped_key = wrap_tuple(key)
     if wrapped_key.count(Ellipsis)== 0:

--- a/holoviews/element/path.py
+++ b/holoviews/element/path.py
@@ -110,11 +110,11 @@ class Path(Geometry):
         return self.clone(extents=(xstart, ystart, xstop, ystop))
 
 
-    def select(self, selection_specs=None, **kwargs):
+    def select(self, *args, **kwargs):
         """
         Bypasses selection on data and sets extents based on selection.
         """
-        return super(Element2D, self).select(selection_specs, **kwargs)
+        return super(Element2D, self).select(*args, **kwargs)
 
 
     def split(self, start=None, end=None, datatype=None, **kwargs):

--- a/holoviews/plotting/util.py
+++ b/holoviews/plotting/util.py
@@ -477,7 +477,7 @@ def initialize_unbounded(obj, dimensions, key):
     """
     select = dict(zip([d.name for d in dimensions], key))
     try:
-        obj.select([DynamicMap], **select)
+        obj.select(selection_specs=[DynamicMap], **select)
     except KeyError:
         pass
 

--- a/holoviews/tests/core/data/base.py
+++ b/holoviews/tests/core/data/base.py
@@ -11,7 +11,8 @@ from holoviews import Dataset, HoloMap, Dimension
 from holoviews.core.data import concat
 from holoviews.core.data.interface import DataError
 from holoviews.element import Scatter, Curve
-from holoviews.element.comparison import ComparisonTestCase 
+from holoviews.element.comparison import ComparisonTestCase
+from holoviews.util.transform import dim
 
 from collections import OrderedDict
 
@@ -697,6 +698,13 @@ class HeterogeneousColumnTests(HomogeneousColumnTests):
                           kdims=self.kdims, vdims=self.vdims)
         self.assertEquals(row, indexed)
 
+    def test_dataset_select_rows_gender_male_expr(self):
+        row = self.table.select(selection_expr=dim('Gender') == 'M')
+        indexed = Dataset({'Gender': ['M', 'M'], 'Age': [10, 16],
+                           'Weight': [15, 18], 'Height': [0.8,0.6]},
+                          kdims=self.kdims, vdims=self.vdims)
+        self.assertEquals(row, indexed)
+
     def test_dataset_select_rows_gender_male_alias(self):
         row = self.alias_table.select(Gender='M')
         alias_row = self.alias_table.select(gender='M')
@@ -859,9 +867,23 @@ class ScalarColumnTests(object):
         ds = Dataset({'A': 1, 'B': np.arange(10)}, kdims=['A', 'B'])
         self.assertEqual(ds.select(A=1).dimension_values('B'), np.arange(10))
 
+    def test_dataset_scalar_select_expr(self):
+        ds = Dataset({'A': 1, 'B': np.arange(10)}, kdims=['A', 'B'])
+        self.assertEqual(
+            ds.select(selection_expr=dim('A') == 1).dimension_values('B'),
+            np.arange(10)
+        )
+
     def test_dataset_scalar_empty_select(self):
         ds = Dataset({'A': 1, 'B': np.arange(10)}, kdims=['A', 'B'])
         self.assertEqual(ds.select(A=0).dimension_values('B'), np.array([]))
+
+    def test_dataset_scalar_empty_select_expr(self):
+        ds = Dataset({'A': 1, 'B': np.arange(10)}, kdims=['A', 'B'])
+        self.assertEqual(
+            ds.select(selection_expr=dim('A') == 0).dimension_values('B'),
+            np.array([])
+        )
 
     def test_dataset_scalar_sample(self):
         ds = Dataset({'A': 1, 'B': np.arange(10)}, kdims=['A', 'B'])

--- a/holoviews/tests/element/testelementselect.py
+++ b/holoviews/tests/element/testelementselect.py
@@ -117,7 +117,7 @@ class DimensionedSelectionTest(ComparisonTestCase):
     def test_selection_spec_positional_error_message(self):
         s, e = '1999-12-31', '2000-1-2'
         curve = self.datetime_fn()
-        with self.assertRaisesRegex(
+        with self.assertRaisesRegexp(
                 ValueError, "Use the selection_specs keyword"
         ):
             curve.select((Curve,), time=(s, e))

--- a/holoviews/tests/element/testelementselect.py
+++ b/holoviews/tests/element/testelementselect.py
@@ -86,7 +86,9 @@ class DimensionedSelectionTest(ComparisonTestCase):
         self.assertEqual(selection, hmap1 + hmap2)
 
     def test_spec_duplicate_dim_select(self):
-        selection = self.duplicate_map.select((HoloMap,), x=(0, 1), y=(1, 3))
+        selection = self.duplicate_map.select(
+            selection_specs=(HoloMap,), x=(0, 1), y=(1, 3)
+        )
         self.assertEqual(selection, self.duplicate_map[0:1, 1:3])
 
     def test_duplicate_dim_select(self):
@@ -102,7 +104,8 @@ class DimensionedSelectionTest(ComparisonTestCase):
         curve = self.datetime_fn()
         overlay = curve * self.datetime_fn()
         for el in [curve, overlay]:
-            self.assertEqual(el.select(time=(s, e)), el[s:e])
+            v = el.select(time=(s, e))
+            self.assertEqual(v, el[s:e])
             self.assertEqual(el.select(time=
                 (dt.datetime(1999, 12, 31), dt.datetime(2000, 1, 2))), el[s:e]
             )
@@ -110,3 +113,11 @@ class DimensionedSelectionTest(ComparisonTestCase):
                 self.assertEqual(el.select(
                     time=(pd.Timestamp(s), pd.Timestamp(e))
                 ), el[pd.Timestamp(s):pd.Timestamp(e)])
+
+    def test_selection_spec_positional_error_message(self):
+        s, e = '1999-12-31', '2000-1-2'
+        curve = self.datetime_fn()
+        with self.assertRaisesRegex(
+                ValueError, "Use the selection_specs keyword"
+        ):
+            curve.select((Curve,), time=(s, e))

--- a/holoviews/util/transform.py
+++ b/holoviews/util/transform.py
@@ -322,7 +322,16 @@ class dim(object):
                     applies &= arg.applies(dataset)
         return applies
 
-    def apply(self, dataset, flat=False, expanded=None, ranges={}, all_values=False):
+    def apply(
+            self,
+            dataset,
+            flat=False,
+            expanded=None,
+            ranges={},
+            all_values=False,
+            keep_index=False,
+            compute=True,
+    ):
         """Evaluates the transform on the supplied dataset.
 
         Args:
@@ -334,6 +343,10 @@ class dim(object):
                Whether to evaluate on all available values, for some
                element types, such as Graphs, this may include values
                not included in the referenced column
+           keep_index: For data types that support indexes, whether the index
+               should be preserved in the result.
+           compute: For data types that support lazy evaluation, whether
+               the result should be computed before it is returned.
 
         Returns:
             values: NumPy array computed by evaluating the expression
@@ -346,7 +359,15 @@ class dim(object):
             if dimension in dataset.kdims and all_values:
                 dimension = dataset.nodes.kdims[2]
             dataset = dataset if dimension in dataset else dataset.nodes
-        data = dataset.dimension_values(dimension, expanded=expanded, flat=flat)
+
+        data = dataset.interface.values(
+            dataset,
+            dimension,
+            expanded=expanded,
+            flat=flat,
+            compute=compute,
+            keep_index=keep_index
+        )
         for o in self.ops:
             args = o['args']
             fn_args = [data]


### PR DESCRIPTION
This PR adds a new `selection_expr` argument to the `Dataset.select` method. This argument may be set to a `holoviews.dim` expression as a way to select rows from a dataset using symbolic expressions.

For example:
```python
import holoviews as hv
import pandas as pd
from holoviews import dim
import dask.dataframe as dd

df = pd.DataFrame({
    'a': [1, 1, 3, 3, 2, 2, 0, 0],
    'b': [10, 20, 30, 40, 10, 20, 30, 40],
    'c': ['A', 'A', 'B', 'B', 'C', 'C', 'D', 'D'],
    'd': [-1, -2, -3, -4, -5, -6, -7, -8]
})

ds = hv.Dataset(df)

print(ds.data)
```
```
   a   b  c  d
0  1  10  A -1
1  1  20  A -2
2  3  30  B -3
3  3  40  B -4
4  2  10  C -5
5  2  20  C -6
6  0  30  D -7
7  0  40  D -8
```
```python
print(ds.select(selection_expr=(dim('b') >= 20) & (dim('a') % 2 == 0)).data)
```
```
   a   b  c  d
5  2  20  C -6
6  0  30  D -7
7  0  40  D -8
```

As long as the expressions are compatible with Dask DataFrames, this also works for `Dataset`s backed by Dask dataframes.

```python
ddf = dd.from_pandas(df, npartitions=2)
dds = ds.clone(data=ddf)
print(dds.select(selection_expr=(dim('b') >= 30)).data)
```
```
Dask DataFrame Structure:
                   a      b       c      d
npartitions=2                             
0              int64  int64  object  int64
4                ...    ...     ...    ...
7                ...    ...     ...    ...
Dask Name: getitem, 8 tasks
```
```python
print(dds.select(selection_expr=(dim('b') >= 30)).data.compute())
```
```
   a   b  c  d
2  3  30  B -3
3  3  40  B -4
6  0  30  D -7
7  0  40  D -8
```

Not all expressions currently work with Dask data structures. This is something I'd like to improve, but I think that should be in a separate PR.

@jlstevens @philippjfr 
