### PR TITLE
Support selections across all dimensions in element.dataset

### DIFF
--- a/holoviews/core/data/__init__.py
+++ b/holoviews/core/data/__init__.py
@@ -391,18 +391,26 @@ argument to specify a selection specification""")
 
         if selection_specs is not None and not isinstance(selection_specs, (list, tuple)):
             selection_specs = [selection_specs]
+
+        # Get reference to the dataset that selections will be applied to
+        if (self.dataset is not None
+                and self.interface == self.dataset.interface):
+            # We can operate directly on self.dataset so select has access to
+            # all of the dimensions in dataset
+            dataset = self.dataset
+        else:
+            dataset = self
+
         selection = {dim_name: sel for dim_name, sel in selection.items()
-                     if dim_name in self.dimensions()+['selection_mask']}
+                     if dim_name in dataset.dimensions()+['selection_mask']}
         if (selection_specs and not any(self.matches(sp) for sp in selection_specs)
                 or (not selection and not selection_expr)):
             return self
 
         # Handle selection dim expression
         if selection_expr is not None:
-            mask = selection_expr.apply(self, compute=False, keep_index=True)
-            dataset = self[mask]
-        else:
-            dataset = self
+            mask = selection_expr.apply(dataset, compute=False, keep_index=True)
+            dataset = dataset[mask]
 
         # Handle selection kwargs
         if selection:

--- a/holoviews/core/data/__init__.py
+++ b/holoviews/core/data/__init__.py
@@ -393,8 +393,7 @@ argument to specify a selection specification""")
             selection_specs = [selection_specs]
 
         # Get reference to the dataset that selections will be applied to
-        if (self.dataset is not None
-                and self.interface == self.dataset.interface):
+        if self.interface == self.dataset.interface:
             # We can operate directly on self.dataset so select has access to
             # all of the dimensions in dataset
             dataset = self.dataset

--- a/holoviews/core/data/multipath.py
+++ b/holoviews/core/data/multipath.py
@@ -59,7 +59,7 @@ class MultiInterface(Interface):
             return
 
         from holoviews.element import Polygons
-        ds = cls._inner_dataset_template(dataset)
+        ds = cls._inner_dataset_template(dataset, vdims)
         for d in dataset.data:
             ds.data = d
             ds.interface.validate(ds, vdims)
@@ -76,7 +76,7 @@ class MultiInterface(Interface):
 
 
     @classmethod
-    def _inner_dataset_template(cls, dataset):
+    def _inner_dataset_template(cls, dataset, validate_vdims=True):
         """
         Returns a Dataset template used as a wrapper around the data
         contained within the multi-interface dataset.
@@ -84,7 +84,8 @@ class MultiInterface(Interface):
         from . import Dataset
         vdims = dataset.vdims if getattr(dataset, 'level', None) is None else []
         return Dataset(dataset.data[0], datatype=cls.subtypes,
-                       kdims=dataset.kdims, vdims=vdims)
+                       kdims=dataset.kdims, vdims=vdims,
+                       _validate_vdims=validate_vdims)
 
     @classmethod
     def dimension_type(cls, dataset, dim):

--- a/holoviews/core/dimension.py
+++ b/holoviews/core/dimension.py
@@ -502,24 +502,6 @@ class LabelledData(param.Parameterized):
             except DataError:
                 # Dataset not compatible with input data
                 pass
-        if self._dataset is None:
-            # Create a default Dataset to wrap input data
-            try:
-                kdims = list(params.get('kdims', []))
-                vdims = list(params.get('vdims', []))
-                dims = kdims + vdims
-                dataset = Dataset(
-                    self.data,
-                    kdims=dims if dims else None
-                )
-                if len(dataset.dimensions()) == 0:
-                    # No dimensions could be auto-detected in data
-                    raise DataError("No dimensions detected")
-                self._dataset = dataset
-            except DataError:
-                # Data not supported by any storage backend. leave _dataset as
-                # None
-                pass
 
         self._id = None
         self.id = id
@@ -544,6 +526,11 @@ class LabelledData(param.Parameterized):
 
     @property
     def dataset(self):
+        from . import Dataset, DataError
+        if self._dataset is None:
+            self._dataset = Dataset(self, _validate_vdims=False)
+            if hasattr(self, '_binned'):
+                self._dataset._binned = self._binned
         return self._dataset
 
     @property

--- a/holoviews/core/dimension.py
+++ b/holoviews/core/dimension.py
@@ -526,7 +526,7 @@ class LabelledData(param.Parameterized):
 
     @property
     def dataset(self):
-        from . import Dataset, DataError
+        from . import Dataset
         if self._dataset is None:
             self._dataset = Dataset(self, _validate_vdims=False)
             if hasattr(self, '_binned'):

--- a/holoviews/element/chart.py
+++ b/holoviews/element/chart.py
@@ -193,13 +193,6 @@ class Histogram(Chart):
             # This is so that dataset contains the data needed to reconstruct
             # the element.
             self._dataset = dataset.clone()
-        elif self.dataset is None:
-            kdim = self.kdims[0].name
-            vdim = self.vdims[0].name
-            self._dataset = Dataset({
-                kdim: self.dimension_values(kdim),
-                vdim: self.dimension_values(vdim),
-            }, kdims=kdim, vdims=vdim)
 
     def clone(self, data=None, shared_data=True, new_type=None, *args, **overrides):
         if 'dataset' in overrides:

--- a/holoviews/element/chart.py
+++ b/holoviews/element/chart.py
@@ -229,15 +229,13 @@ class Histogram(Chart):
                 or (not selection and not selection_expr)):
             return self
 
-        if self.dataset is not None and self._operation_kwargs is not None:
+        if self._operation_kwargs is not None:
             # We have what we need to perform selection on dataset and
             # regenerate the histogram.
             selected_dataset = self.dataset.select(selection_expr, **selection)
             selected = histogram(selected_dataset, **self._operation_kwargs)
-            if selected_dataset.dataset is not None:
-                selected._dataset = selected_dataset.dataset
-            else:
-                selected._dataset = selected_dataset
+            selected._dataset = selected_dataset.dataset
+
             return selected
         else:
             # Perform selection directly on histogram

--- a/holoviews/element/chart.py
+++ b/holoviews/element/chart.py
@@ -193,6 +193,13 @@ class Histogram(Chart):
             # This is so that dataset contains the data needed to reconstruct
             # the element.
             self._dataset = dataset.clone()
+        elif self.dataset is None:
+            kdim = self.kdims[0].name
+            vdim = self.vdims[0].name
+            self._dataset = Dataset({
+                kdim: self.dimension_values(kdim),
+                vdim: self.dimension_values(vdim),
+            }, kdims=kdim, vdims=vdim)
 
     def clone(self, data=None, shared_data=True, new_type=None, *args, **overrides):
         if 'dataset' in overrides:

--- a/holoviews/tests/core/testdatasetproperty.py
+++ b/holoviews/tests/core/testdatasetproperty.py
@@ -34,7 +34,11 @@ class ConstructorTestCase(DatasetPropertyTestCase):
 
     def test_constructor_curve(self):
         element = Curve(self.df)
-        expected = Dataset(self.df)
+        expected = Dataset(
+            self.df,
+            kdims=self.df.columns[0],
+            vdims=self.df.columns[1:].tolist(),
+        )
         self.assertEqual(element.dataset, expected)
 
 

--- a/holoviews/tests/core/testdatasetproperty.py
+++ b/holoviews/tests/core/testdatasetproperty.py
@@ -147,6 +147,26 @@ class SelectTestCase(DatasetPropertyTestCase):
             self.ds.select(b=10)
         )
 
+    def test_select_curve_all_dimensions(self):
+        curve1 = self.ds.to.curve('a', 'b', groupby=[])
+
+        # Check curve1 dataset property
+        self.assertEqual(curve1.dataset, self.ds)
+
+        # Down select curve 1 on b, which is a value dimension, and c,
+        # which is a dimension in the original dataset, but not a kdim or vdim
+        curve2 = curve1.select(b=10, c='A')
+
+        # This selection should be equivalent to down selecting the dataset
+        # before creating the curve
+        self.assertEqual(
+            curve2,
+            self.ds.select(b=10, c='A').to.curve('a', 'b', groupby=[])
+        )
+
+        # Check that we get the same result when using a dim expression
+        curve3 = curve1.select((dim('b') == 10) & (dim('c') == 'A'))
+        self.assertEqual(curve3, curve2)
 
 class HistogramTestCase(DatasetPropertyTestCase):
 


### PR DESCRIPTION
## Overview
This PR builds on top of following PRs:
 - https://github.com/pyviz/holoviews/pull/3919
 - https://github.com/pyviz/holoviews/pull/3920
 - https://github.com/pyviz/holoviews/pull/3921

It updates the `Dataset.select` method to support down selecting an element using all of the dimensions in the element's `.dataset` property. Without this, it's only possible to down select elements using the key and value dimensions.

## Example 1: Points

Create a sample 3-dimensional dataset.  `x` and `y` are independently drawn from the standard normal distribution and `r` is calculated to be the radius of each point from the origin.
```python
import numpy as np
import pandas as pd
import holoviews as hv
from holoviews import dim
hv.extension('plotly')

np.random.seed(1)
df = pd.DataFrame(np.random.randn(100, 2), columns=['x', 'y'])

# Add radius column
df['r'] = (df.x ** 2 + df.y ** 2) ** 0.5

ds = hv.Dataset(df)
```

Then create a `Points` element from this dataset with `x` and `y` as key dimensions.
```python
points = ds.to.points(kdims=['x', 'y'], groupby=[])
points
```
![newplot-2](https://user-images.githubusercontent.com/15064365/63551037-0ec66400-c502-11e9-98aa-628a9065719a.png)

Prior to https://github.com/pyviz/holoviews/pull/3919, the `points` object would not have dimension information about `r`, so it would not be possible to perform a selection on `points` using `r`.  But, with the addition of the `.dataset` property (and the changes in this PR), it's now possible to perform a selection using `r` as well.

Perform selection using `x` (a key dimension) and `r` (neither a key nor value dimension):
```python
points * points.select(x=(0, None), r=(0, 1.5))
```
![newplot-3](https://user-images.githubusercontent.com/15064365/63551144-52b96900-c502-11e9-8d0f-6be187ee5c10.png)

## Example 2: Histogram
This PR uses https://github.com/pyviz/holoviews/pull/3921 to support rebinning the histogram samples in response to selections.

Here's an example of performing a selection directly on the histogram element that uses both `x` (the histogram's key dimension) and `r` (neither a key nor value dimension):

```python
hist1 = hv.operation.histogram(points, num_bins=10, dynamic=False, normed=False)
hist2 = hist1.select((dim('x') > 0) & (dim('r') < 1.5))
hist1 * hist2
```
![newplot-4](https://user-images.githubusercontent.com/15064365/63551502-56012480-c503-11e9-96e6-52da4112b95a.png)

This example also demonstrates the dim expression support that was added to `select` in https://github.com/pyviz/holoviews/pull/3920.
