### PR TITLE
Add `visible` style option for simple plotly/bokeh plots.

### DIFF
--- a/holoviews/plotting/bokeh/annotation.py
+++ b/holoviews/plotting/bokeh/annotation.py
@@ -28,7 +28,7 @@ from .util import date_to_integer
 
 class TextPlot(ElementPlot, AnnotationPlot):
 
-    style_opts = text_properties+['color', 'angle']
+    style_opts = text_properties+['color', 'angle', 'visible']
     _plot_methods = dict(single='text', batched='text')
 
     def get_data(self, element, ranges, style):
@@ -86,7 +86,7 @@ class LabelsPlot(ColorbarPlot, AnnotationPlot):
                                       allow_None=True, doc="""
         Deprecated in favor of color style mapping, e.g. `color=dim('color')`""")
 
-    style_opts = text_properties + ['cmap', 'angle']
+    style_opts = text_properties + ['cmap', 'angle', 'visible']
 
     _nonvectorized_styles = ['cmap']
 
@@ -128,7 +128,7 @@ class LabelsPlot(ColorbarPlot, AnnotationPlot):
 
 class LineAnnotationPlot(ElementPlot, AnnotationPlot):
 
-    style_opts = line_properties + ['level']
+    style_opts = line_properties + ['level', 'visible']
 
     apply_ranges = param.Boolean(default=False, doc="""
         Whether to include the annotation in axis range calculations.""")
@@ -174,7 +174,7 @@ class SplinePlot(ElementPlot, AnnotationPlot):
     Does not support matplotlib Path codes.
     """
 
-    style_opts = line_properties
+    style_opts = line_properties + ['visible']
     _plot_methods = dict(single='bezier')
 
     def get_data(self, element, ranges, style):

--- a/holoviews/plotting/bokeh/chart.py
+++ b/holoviews/plotting/bokeh/chart.py
@@ -52,7 +52,7 @@ class PointPlot(LegendPlot, ColorbarPlot):
       Function applied to size values before applying scaling,
       to remove values lower than zero.""")
 
-    style_opts = (['cmap', 'palette', 'marker', 'size', 'angle'] +
+    style_opts = (['cmap', 'palette', 'marker', 'size', 'angle', 'visible'] +
                   line_properties + fill_properties)
 
     _plot_methods = dict(single='scatter', batched='scatter')
@@ -129,7 +129,7 @@ class PointPlot(LegendPlot, ColorbarPlot):
 
         # Angles need special handling since they are tied to the
         # marker in certain cases
-        has_angles = False 
+        has_angles = False
         for (key, el), zorder in zip(element.data.items(), zorders):
             self.param.set_param(**self.lookup_options(el, 'plot').options)
             style = self.lookup_options(element.last, 'style')
@@ -211,9 +211,9 @@ class VectorFieldPlot(ColorbarPlot):
         transforms using the magnitude option, e.g.
         `dim('Magnitude').norm()`.""")
 
-    style_opts = line_properties + ['scale', 'cmap']
+    style_opts = line_properties + ['scale', 'cmap', 'visible']
 
-    _nonvectorized_styles = ['scale', 'cmap']
+    _nonvectorized_styles = ['scale', 'cmap', 'visible']
 
     _plot_methods = dict(single='segment')
 
@@ -324,8 +324,8 @@ class CurvePlot(ElementPlot):
         default is 'linear', other options include 'steps-mid',
         'steps-pre' and 'steps-post'.""")
 
-    style_opts = line_properties
-    _nonvectorized_styles = line_properties
+    style_opts = line_properties + ['visible']
+    _nonvectorized_styles = line_properties + ['visible']
 
     _plot_methods = dict(single='line', batched='multi_line')
     _batched_style_opts = line_properties
@@ -391,10 +391,10 @@ class CurvePlot(ElementPlot):
 
 class HistogramPlot(ColorbarPlot):
 
-    style_opts = line_properties + fill_properties + ['cmap']
+    style_opts = line_properties + fill_properties + ['cmap', 'visible']
     _plot_methods = dict(single='quad')
 
-    _nonvectorized_styles = ['line_dash']
+    _nonvectorized_styles = ['line_dash', 'visible']
 
     def get_data(self, element, ranges, style):
         if self.invert_axes:
@@ -497,9 +497,9 @@ class SideHistogramPlot(HistogramPlot):
 
 class ErrorPlot(ColorbarPlot):
 
-    style_opts = line_properties + ['lower_head', 'upper_head']
+    style_opts = line_properties + ['lower_head', 'upper_head', 'visible']
 
-    _nonvectorized_styles = ['line_dash']
+    _nonvectorized_styles = ['line_dash', 'visible']
 
     _mapping = dict(base="base", upper="upper", lower="lower")
 
@@ -553,7 +553,7 @@ class ErrorPlot(ColorbarPlot):
 
 class SpreadPlot(ElementPlot):
 
-    style_opts = line_properties + fill_properties
+    style_opts = line_properties + fill_properties + ['visible']
     _no_op_style = style_opts
 
     _plot_methods = dict(single='patch')
@@ -659,7 +659,7 @@ class SpikesPlot(ColorbarPlot):
                                       allow_None=True, doc="""
         Deprecated in favor of color style mapping, e.g. `color=dim('color')`""")
 
-    style_opts = (['color', 'cmap', 'palette'] + line_properties)
+    style_opts = (['color', 'cmap', 'palette', 'visible'] + line_properties)
 
     _plot_methods = dict(single='segment')
 
@@ -767,9 +767,11 @@ class BarPlot(ColorbarPlot, LegendPlot):
                                       allow_None=True, doc="""
        Deprecated; use stacked option instead.""")
 
-    style_opts = line_properties + fill_properties + ['width', 'bar_width', 'cmap']
+    style_opts = (line_properties
+                  + fill_properties
+                  + ['width', 'bar_width', 'cmap', 'visible'])
 
-    _nonvectorized_styles = ['bar_width', 'cmap', 'width']
+    _nonvectorized_styles = ['bar_width', 'cmap', 'width', 'visible']
 
     _plot_methods = dict(single=('vbar', 'hbar'))
 

--- a/holoviews/plotting/bokeh/heatmap.py
+++ b/holoviews/plotting/bokeh/heatmap.py
@@ -52,7 +52,7 @@ class HeatMapPlot(ColorbarPlot):
 
     style_opts = (['xmarks_' + p for p in line_properties] +
                   ['ymarks_' + p for p in line_properties] +
-                  ['cmap', 'color', 'dilate'] + line_properties + fill_properties)
+                  ['cmap', 'color', 'dilate', 'visible'] + line_properties + fill_properties)
 
     _categorical = True
 

--- a/holoviews/plotting/bokeh/hex_tiles.py
+++ b/holoviews/plotting/bokeh/hex_tiles.py
@@ -138,7 +138,7 @@ class HexTilesPlot(ColorbarPlot):
 
     _plot_methods = dict(single='hex_tile')
 
-    style_opts = ['cmap', 'color', 'scale'] + line_properties + fill_properties
+    style_opts = ['cmap', 'color', 'scale', 'visible'] + line_properties + fill_properties
 
     _nonvectorized_styles = ['cmap', 'line_dash']
 

--- a/holoviews/plotting/bokeh/path.py
+++ b/holoviews/plotting/bokeh/path.py
@@ -26,7 +26,7 @@ class PathPlot(LegendPlot, ColorbarPlot):
                                       allow_None=True, doc="""
         Deprecated in favor of color style mapping, e.g. `color=dim('color')`""")
 
-    style_opts = line_properties + ['cmap']
+    style_opts = line_properties + ['cmap', 'visible']
     _plot_methods = dict(single='multi_line', batched='multi_line')
     _mapping = dict(xs='xs', ys='ys')
     _batched_style_opts = line_properties
@@ -270,7 +270,7 @@ class ContourPlot(PathPlot):
 
 class PolygonPlot(ContourPlot):
 
-    style_opts = ['cmap'] + line_properties + fill_properties
+    style_opts = ['cmap', 'visible'] + line_properties + fill_properties
     _plot_methods = dict(single='patches', batched='patches')
     _batched_style_opts = line_properties + fill_properties
     _color_style = 'fill_color'

--- a/holoviews/plotting/bokeh/raster.py
+++ b/holoviews/plotting/bokeh/raster.py
@@ -19,7 +19,7 @@ class RasterPlot(ColorbarPlot):
     show_legend = param.Boolean(default=False, doc="""
         Whether to show legend for the plot.""")
 
-    style_opts = ['cmap', 'alpha']
+    style_opts = ['cmap', 'alpha', 'visible']
 
     _nonvectorized_styles = style_opts
 
@@ -120,7 +120,7 @@ class RasterPlot(ColorbarPlot):
 
 class RGBPlot(ElementPlot):
 
-    style_opts = ['alpha']
+    style_opts = ['alpha', 'visible']
 
     _nonvectorized_styles = style_opts
 
@@ -194,7 +194,7 @@ class QuadMeshPlot(ColorbarPlot):
     show_legend = param.Boolean(default=False, doc="""
         Whether to show legend for the plot.""")
 
-    style_opts = ['cmap', 'color'] + line_properties + fill_properties
+    style_opts = ['cmap', 'color', 'visible'] + line_properties + fill_properties
 
     _nonvectorized_styles = style_opts
 

--- a/holoviews/plotting/bokeh/tabular.py
+++ b/holoviews/plotting/bokeh/tabular.py
@@ -32,7 +32,7 @@ class TablePlot(BokehPlot, GenericElementPlot):
 
     style_opts = ['row_headers', 'selectable', 'editable',
                   'sortable', 'fit_columns', 'scroll_to_selection',
-                  'index_position']
+                  'index_position', 'visible']
 
     _stream_data = True
 

--- a/holoviews/plotting/plotly/annotation.py
+++ b/holoviews/plotting/plotly/annotation.py
@@ -13,7 +13,7 @@ class LabelPlot(ScatterPlot):
     yoffset = param.Number(default=None, doc="""
       Amount of offset to apply to labels along x-axis.""")
 
-    style_opts = ['color', 'family', 'size']
+    style_opts = ['visible', 'color', 'family', 'size']
 
     _nonvectorized_styles = []
 

--- a/holoviews/plotting/plotly/chart.py
+++ b/holoviews/plotting/plotly/chart.py
@@ -28,10 +28,17 @@ class ScatterPlot(ChartPlot, ColorbarPlot):
       Index of the dimension from which the color will the drawn""")
 
     style_opts = [
-        'marker', 'color', 'cmap', 'alpha', 'size', 'sizemin', 'selectedpoints'
+        'visible',
+        'marker',
+        'color',
+        'cmap',
+        'alpha',
+        'size',
+        'sizemin',
+        'selectedpoints',
     ]
 
-    _nonvectorized_styles = ['cmap', 'alpha', 'sizemin', 'selectedpoints']
+    _nonvectorized_styles = ['visible', 'cmap', 'alpha', 'sizemin', 'selectedpoints']
 
     trace_kwargs = {'type': 'scatter', 'mode': 'markers'}
 
@@ -62,7 +69,7 @@ class CurvePlot(ChartPlot, ColorbarPlot):
 
     trace_kwargs = {'type': 'scatter', 'mode': 'lines'}
 
-    style_opts = ['color', 'dash', 'line_width']
+    style_opts = ['visible', 'color', 'dash', 'line_width']
 
     _nonvectorized_styles = style_opts
 
@@ -76,7 +83,7 @@ class CurvePlot(ChartPlot, ColorbarPlot):
 
 class AreaPlot(ChartPlot):
 
-    style_opts = ['color', 'dash', 'line_width']
+    style_opts = ['visible', 'color', 'dash', 'line_width']
 
     trace_kwargs = {'type': 'scatter', 'mode': 'lines'}
 
@@ -112,7 +119,7 @@ class AreaPlot(ChartPlot):
 
 class SpreadPlot(ChartPlot):
 
-    style_opts = ['color', 'dash', 'line_width']
+    style_opts = ['visible', 'color', 'dash', 'line_width']
 
     trace_kwargs = {'type': 'scatter', 'mode': 'lines'}
 
@@ -129,13 +136,13 @@ class SpreadPlot(ChartPlot):
         upper = mean + pos_error
         return [{x: xs, y: lower, 'fill': None},
                 {x: xs, y: upper, 'fill': 'tonext'+y}]
-    
+
 
 class ErrorBarsPlot(ChartPlot, ColorbarPlot):
 
     trace_kwargs = {'type': 'scatter', 'mode': 'lines', 'line': {'width': 0}}
 
-    style_opts = ['color', 'dash', 'line_width', 'thickness']
+    style_opts = ['visible', 'color', 'dash', 'line_width', 'thickness']
 
     _nonvectorized_styles = style_opts
 
@@ -175,6 +182,8 @@ class BarPlot(ElementPlot):
        Element, which will stacked.""")
 
     stacked = param.Boolean(default=False)
+
+    style_opts = ['visible']
 
     trace_kwargs = {'type': 'bar'}
 
@@ -287,7 +296,7 @@ class HistogramPlot(ElementPlot):
 
     trace_kwargs = {'type': 'bar'}
 
-    style_opts = ['color', 'line_color', 'line_width', 'opacity']
+    style_opts = ['visible', 'color', 'line_color', 'line_width', 'opacity']
 
     _style_key = 'marker'
 

--- a/holoviews/plotting/plotly/chart3d.py
+++ b/holoviews/plotting/plotly/chart3d.py
@@ -41,7 +41,7 @@ class SurfacePlot(Chart3DPlot, ColorbarPlot):
 
     trace_kwargs = {'type': 'surface'}
 
-    style_opts = ['alpha', 'lighting', 'lightposition', 'cmap']
+    style_opts = ['visible', 'alpha', 'lighting', 'lightposition', 'cmap']
 
     def graph_options(self, element, ranges, style):
         opts = super(SurfacePlot, self).graph_options(element, ranges, style)

--- a/holoviews/plotting/plotly/element.py
+++ b/holoviews/plotting/plotly/element.py
@@ -213,9 +213,11 @@ class ElementPlot(PlotlyPlot, GenericElementPlot):
             opts[self._style_key] = {STYLE_ALIASES.get(k, k): v
                                      for k, v in styles.items()}
 
-            # Move selectedpoints from style key back to root
-            if 'selectedpoints' in opts.get(self._style_key, {}):
-                opts['selectedpoints'] = opts[self._style_key].pop('selectedpoints')
+            # Move certain options from the style key back to root
+            for k in ['selectedpoints', 'visible']:
+                if k in opts.get(self._style_key, {}):
+                    opts[k] = opts[self._style_key].pop(k)
+
         else:
             opts.update({STYLE_ALIASES.get(k, k): v
                          for k, v in style.items() if k != 'cmap'})

--- a/holoviews/plotting/plotly/raster.py
+++ b/holoviews/plotting/plotly/raster.py
@@ -9,7 +9,7 @@ from .element import ColorbarPlot
 
 class RasterPlot(ColorbarPlot):
 
-    style_opts = ['cmap', 'alpha']
+    style_opts = ['visible', 'cmap', 'alpha']
 
     trace_kwargs = {'type': 'heatmap'}
 

--- a/holoviews/plotting/plotly/stats.py
+++ b/holoviews/plotting/plotly/stats.py
@@ -14,7 +14,7 @@ class BivariatePlot(ChartPlot, ColorbarPlot):
 
     trace_kwargs = {'type': 'histogram2dcontour'}
 
-    style_opts = ['cmap', 'showlabels', 'labelfont', 'labelformat', 'showlines']
+    style_opts = ['visible', 'cmap', 'showlabels', 'labelfont', 'labelformat', 'showlines']
 
     _style_key = 'contours'
 
@@ -58,7 +58,7 @@ class DistributionPlot(ElementPlot):
     filled = param.Boolean(default=True, doc="""
         Whether the bivariate contours should be filled.""")
 
-    style_opts = ['color', 'dash', 'line_width']
+    style_opts = ['visible', 'color', 'dash', 'line_width']
 
     trace_kwargs = {'type': 'scatter', 'mode': 'lines'}
 
@@ -112,7 +112,7 @@ class BoxWhiskerPlot(MultiDistributionPlot):
         is drawn as a dashed line inside the box(es). If "sd" the
         standard deviation is also drawn.""")
 
-    style_opts = ['color', 'alpha', 'outliercolor', 'marker', 'size']
+    style_opts = ['visible', 'color', 'alpha', 'outliercolor', 'marker', 'size']
 
     trace_kwargs = {'type': 'box'}
 
@@ -136,7 +136,7 @@ class ViolinPlot(MultiDistributionPlot):
         is drawn as a dashed line inside the box(es). If "sd" the
         standard deviation is also drawn.""")
 
-    style_opts = ['color', 'alpha', 'outliercolor', 'marker', 'size']
+    style_opts = ['visible', 'color', 'alpha', 'outliercolor', 'marker', 'size']
 
     trace_kwargs = {'type': 'violin'}
 

--- a/holoviews/plotting/plotly/tabular.py
+++ b/holoviews/plotting/plotly/tabular.py
@@ -13,7 +13,7 @@ class TablePlot(ElementPlot):
 
     trace_kwargs = {'type': 'table'}
 
-    style_opts = ['line', 'fill', 'align', 'font', 'cell_height']
+    style_opts = ['visible', 'line', 'fill', 'align', 'font', 'cell_height']
 
     _style_key = 'cells'
 

--- a/holoviews/tests/plotting/plotly/testareaplot.py
+++ b/holoviews/tests/plotting/plotly/testareaplot.py
@@ -50,3 +50,8 @@ class TestAreaPlot(TestPlotlyPlot):
         self.assertEqual(state['data'][1]['fill'], 'tonextx')
         self.assertEqual(state['layout']['xaxis']['range'], [0.5, 3])
         self.assertEqual(state['layout']['yaxis']['range'], [0, 2])
+
+    def test_area_visible(self):
+        curve = Area([1, 2, 3]).options(visible=False)
+        state = self._get_plot_state(curve)
+        self.assertEqual(state['data'][0]['visible'], False)

--- a/holoviews/tests/plotting/plotly/testbarplot.py
+++ b/holoviews/tests/plotting/plotly/testbarplot.py
@@ -60,7 +60,7 @@ class TestBarsPlot(TestPlotlyPlot):
         self.assertEqual(state['layout']['yaxis']['title']['text'], 'A, B')
         self.assertEqual(state['layout']['xaxis']['range'], [0, 4])
         self.assertEqual(state['layout']['xaxis']['title']['text'], 'y')
-        
+
     def test_bars_stacked(self):
         bars = Bars([('A', 1, 1), ('B', 2, 2), ('C', 2, 3), ('C', 1, 4)],
                     kdims=['A', 'B']).options(stacked=True)
@@ -92,3 +92,8 @@ class TestBarsPlot(TestPlotlyPlot):
         self.assertEqual(state['layout']['yaxis']['title']['text'], 'A')
         self.assertEqual(state['layout']['xaxis']['range'], [0, 7])
         self.assertEqual(state['layout']['xaxis']['title']['text'], 'y')
+
+    def test_visible(self):
+        element = Bars([3, 2, 1]).options(visible=False)
+        state = self._get_plot_state(element)
+        self.assertEqual(state['data'][0]['visible'], False)

--- a/holoviews/tests/plotting/plotly/testbivariateplot.py
+++ b/holoviews/tests/plotting/plotly/testbivariateplot.py
@@ -41,3 +41,8 @@ class TestBivariatePlot(TestPlotlyPlot):
         state = self._get_plot_state(bivariate)
         trace = state['data'][0]
         self.assertFalse(trace['showscale'])
+
+    def test_visible(self):
+        element = Bivariate(([3, 2, 1], [0, 1, 2])).options(visible=False)
+        state = self._get_plot_state(element)
+        self.assertEqual(state['data'][0]['visible'], False)

--- a/holoviews/tests/plotting/plotly/testboxwhiskerplot.py
+++ b/holoviews/tests/plotting/plotly/testboxwhiskerplot.py
@@ -57,3 +57,8 @@ class TestBoxWhiskerPlot(TestPlotlyPlot):
         self.assertEqual(state['layout']['yaxis']['title']['text'], 'x')
         self.assertEqual(state['layout']['xaxis']['range'], [1, 5])
         self.assertEqual(state['layout']['xaxis']['title']['text'], 'y')
+
+    def test_visible(self):
+        element = BoxWhisker(([3, 2, 1], [0, 1, 2])).options(visible=False)
+        state = self._get_plot_state(element)
+        self.assertEqual(state['data'][0]['visible'], False)

--- a/holoviews/tests/plotting/plotly/testcurveplot.py
+++ b/holoviews/tests/plotting/plotly/testcurveplot.py
@@ -52,3 +52,8 @@ class TestCurvePlot(TestPlotlyPlot):
         curve = Curve([1, 2, 3]).options(line_width=5)
         state = self._get_plot_state(curve)
         self.assertEqual(state['data'][0]['line']['width'], 5)
+
+    def test_visible(self):
+        element = Curve([1, 2, 3]).options(visible=False)
+        state = self._get_plot_state(element)
+        self.assertEqual(state['data'][0]['visible'], False)

--- a/holoviews/tests/plotting/plotly/testdistributionplot.py
+++ b/holoviews/tests/plotting/plotly/testdistributionplot.py
@@ -18,3 +18,8 @@ class TestDistributionPlot(TestPlotlyPlot):
         self.assertEqual(state['data'][0]['type'], 'scatter')
         self.assertEqual(state['data'][0]['mode'], 'lines')
         self.assertEqual(state['data'][0].get('fill'), None)
+
+    def test_visible(self):
+        element = Distribution([1, 1.1,  2.1, 3, 2, 1, 2.2]).options(visible=False)
+        state = self._get_plot_state(element)
+        self.assertEqual(state['data'][0]['visible'], False)

--- a/holoviews/tests/plotting/plotly/testerrorbarplot.py
+++ b/holoviews/tests/plotting/plotly/testerrorbarplot.py
@@ -26,3 +26,11 @@ class TestErrorBarsPlot(TestPlotlyPlot):
         self.assertEqual(state['data'][0]['error_x']['arrayminus'], np.array([0.5, 1, 2.25]))
         self.assertEqual(state['data'][0]['mode'], 'lines')
         self.assertEqual(state['layout']['xaxis']['range'], [0.5, 5.25])
+
+    def test_visible(self):
+        element = ErrorBars(
+            [(0, 1, 0.5), (1, 2, 1), (2, 3, 2.25)],
+            vdims=['y', 'y2']
+        ).options(visible=False)
+        state = self._get_plot_state(element)
+        self.assertEqual(state['data'][0]['visible'], False)

--- a/holoviews/tests/plotting/plotly/testhistogram.py
+++ b/holoviews/tests/plotting/plotly/testhistogram.py
@@ -51,3 +51,8 @@ class TestHistogramPlot(TestPlotlyPlot):
         state = self._get_plot_state(hist)
         marker = state['data'][0]['marker']
         self.assert_property_values(marker, props)
+
+    def test_visible(self):
+        element = Histogram((self.edges, self.frequencies)).options(visible=False)
+        state = self._get_plot_state(element)
+        self.assertEqual(state['data'][0]['visible'], False)

--- a/holoviews/tests/plotting/plotly/testimageplot.py
+++ b/holoviews/tests/plotting/plotly/testimageplot.py
@@ -34,3 +34,10 @@ class TestImagePlot(TestPlotlyPlot):
         self.assertEqual(state['data'][0]['zmax'], 4)
         self.assertEqual(state['layout']['yaxis']['range'], [0.5, 3.5])
         self.assertEqual(state['layout']['xaxis']['range'], [-0.5, 1.5])
+
+    def test_visible(self):
+        element = Image(
+            ([1, 2, 3], [0, 1], np.array([[0, 1, 2], [2, 3, 4]]))
+        ).options(visible=False)
+        state = self._get_plot_state(element)
+        self.assertEqual(state['data'][0]['visible'], False)

--- a/holoviews/tests/plotting/plotly/testlabelplot.py
+++ b/holoviews/tests/plotting/plotly/testlabelplot.py
@@ -45,3 +45,8 @@ class TestLabelsPlot(TestPlotlyPlot):
         labels = Labels([(0, 3, 0), (1, 2, 1), (2, 1, 1)]).options(yoffset=0.5)
         state = self._get_plot_state(labels)
         self.assertEqual(state['data'][0]['y'], np.array([3.5, 2.5, 1.5]))
+
+    def test_visible(self):
+        element = Labels([(0, 3, 0), (1, 2, 1), (2, 1, 1)]).options(visible=False)
+        state = self._get_plot_state(element)
+        self.assertEqual(state['data'][0]['visible'], False)

--- a/holoviews/tests/plotting/plotly/testpath3d.py
+++ b/holoviews/tests/plotting/plotly/testpath3d.py
@@ -42,3 +42,8 @@ class TestPath3DPlot(TestPlotlyPlot):
         state = self._get_plot_state(path3D)
         self.assertEqual(state['data'][0]['line']['color'], 'red')
         self.assertEqual(state['data'][1]['line']['color'], 'blue')
+
+    def test_visible(self):
+        element = Path3D([(0, 1, 0), (1, 2, 1), (2, 3, 2)]).options(visible=False)
+        state = self._get_plot_state(element)
+        self.assertEqual(state['data'][0]['visible'], False)

--- a/holoviews/tests/plotting/plotly/testquadmeshplot.py
+++ b/holoviews/tests/plotting/plotly/testquadmeshplot.py
@@ -30,3 +30,10 @@ class TestQuadMeshPlot(TestPlotlyPlot):
         self.assertEqual(state['data'][0]['zmax'], 4)
         self.assertEqual(state['layout']['xaxis']['range'], [-0.5, 1.5])
         self.assertEqual(state['layout']['yaxis']['range'], [0.5, 5])
+
+    def test_visible(self):
+        element = QuadMesh(
+            ([1, 2, 4], [0, 1], np.array([[0, 1, 2], [2, 3, 4]]))
+        ).options(visible=False)
+        state = self._get_plot_state(element)
+        self.assertEqual(state['data'][0]['visible'], False)

--- a/holoviews/tests/plotting/plotly/testscatter3dplot.py
+++ b/holoviews/tests/plotting/plotly/testscatter3dplot.py
@@ -28,3 +28,8 @@ class TestScatter3DPlot(TestPlotlyPlot):
         scatter = Scatter3D(([0,1], [2,3], [4,5])).options(size='y')
         state = self._get_plot_state(scatter)
         self.assertEqual(state['data'][0]['marker']['size'], np.array([2, 3]))
+
+    def test_visible(self):
+        element = Scatter3D(([0, 1], [2, 3], [4, 5])).options(visible=False)
+        state = self._get_plot_state(element)
+        self.assertEqual(state['data'][0]['visible'], False)

--- a/holoviews/tests/plotting/plotly/testscatterplot.py
+++ b/holoviews/tests/plotting/plotly/testscatterplot.py
@@ -59,3 +59,8 @@ class TestScatterPlot(TestPlotlyPlot):
         ]).options(selectedpoints=[1, 2])
         state = self._get_plot_state(scatter)
         self.assertEqual(state['data'][0]['selectedpoints'], [1, 2])
+
+    def test_visible(self):
+        element = Scatter([3, 2, 1]).options(visible=False)
+        state = self._get_plot_state(element)
+        self.assertEqual(state['data'][0]['visible'], False)

--- a/holoviews/tests/plotting/plotly/testspreadplot.py
+++ b/holoviews/tests/plotting/plotly/testspreadplot.py
@@ -29,3 +29,11 @@ class TestSpreadPlot(TestPlotlyPlot):
         self.assertEqual(state['data'][1]['fill'], 'tonextx')
         self.assertEqual(state['layout']['xaxis']['range'], [0.5, 5.25])
         self.assertEqual(state['layout']['yaxis']['range'], [0, 2])
+
+    def test_visible(self):
+        element = Spread(
+            [(0, 1, 0.5), (1, 2, 1), (2, 3, 2.25)],
+            vdims=['y', 'y2']
+        ).options(visible=False)
+        state = self._get_plot_state(element)
+        self.assertEqual(state['data'][0]['visible'], False)

--- a/holoviews/tests/plotting/plotly/testsurfaceplot.py
+++ b/holoviews/tests/plotting/plotly/testsurfaceplot.py
@@ -31,3 +31,10 @@ class TestSurfacePlot(TestPlotlyPlot):
         state = self._get_plot_state(img)
         trace = state['data'][0]
         self.assertFalse(trace['showscale'])
+
+    def test_visible(self):
+        element = Surface(
+            ([1, 2, 3], [0, 1], np.array([[0, 1, 2], [2, 3, 4]]))
+        ).options(visible=False)
+        state = self._get_plot_state(element)
+        self.assertEqual(state['data'][0]['visible'], False)

--- a/holoviews/tests/plotting/plotly/testtableplot.py
+++ b/holoviews/tests/plotting/plotly/testtableplot.py
@@ -12,3 +12,8 @@ class TestTablePlot(TestPlotlyPlot):
         self.assertEqual(state['data'][0]['header']['values'], ['x', 'y'])
         self.assertEqual(state['data'][0]['cells']['values'],
                          [['0', '1', '2'], ['1', '2', '3']])
+
+    def test_visible(self):
+        element = Table([(0, 1), (1, 2), (2, 3)], 'x', 'y').options(visible=False)
+        state = self._get_plot_state(element)
+        self.assertEqual(state['data'][0]['visible'], False)

--- a/holoviews/tests/plotting/plotly/testviolinplot.py
+++ b/holoviews/tests/plotting/plotly/testviolinplot.py
@@ -57,3 +57,8 @@ class TestViolinPlot(TestPlotlyPlot):
         self.assertEqual(state['layout']['yaxis']['title']['text'], 'x')
         self.assertEqual(state['layout']['xaxis']['range'], [1, 5])
         self.assertEqual(state['layout']['xaxis']['title']['text'], 'y')
+
+    def test_visible(self):
+        element = Violin([1, 1, 2, 3, 3, 4, 5, 5]).options(visible=False)
+        state = self._get_plot_state(element)
+        self.assertEqual(state['data'][0]['visible'], False)


### PR DESCRIPTION
Setting `visible` to `False` will fully hide the individual element trace.

This option is very useful for the linked selection effort...