### PR TITLE
Fix step interpolation rounding for datetime

### DIFF
--- a/holoviews/operation/element.py
+++ b/holoviews/operation/element.py
@@ -797,9 +797,9 @@ class interpolate_curve(Operation):
         is_datetime = isdatetime(x)
         if is_datetime:
             dt_type = 'datetime64[ns]'
-            x = x.astype(dt_type).astype('int64')
+            x = x.astype(dt_type)
         dvals = tuple(element.dimension_values(d) for d in element.dimensions()[1:])
-        xs, dvals = INTERPOLATE_FUNCS[self.p.interpolation](x.astype('f'), dvals)
+        xs, dvals = INTERPOLATE_FUNCS[self.p.interpolation](x, dvals)
         if is_datetime:
             xs = xs.astype(dt_type)
         return element.clone((xs,)+dvals)

--- a/holoviews/tests/operation/testoperation.py
+++ b/holoviews/tests/operation/testoperation.py
@@ -331,10 +331,10 @@ class OperationTests(ComparisonTestCase):
         values = [0, 1, 2, 3]
         interpolated = interpolate_curve(Curve((dates, values)), interpolation='steps-pre')
         dates_interp = np.array([
-            '2017-01-01T00:00:16.364011520', '2017-01-01T00:00:16.364011520',
-            '2017-01-02T00:01:05.465745408', '2017-01-02T00:01:05.465745408',
-            '2017-01-02T23:59:37.128525824', '2017-01-02T23:59:37.128525824',
-            '2017-01-04T00:00:26.230259712'
+            '2017-01-01T00:00:00', '2017-01-01T00:00:00',
+            '2017-01-02T00:00:00', '2017-01-02T00:00:00',
+            '2017-01-03T00:00:00', '2017-01-03T00:00:00',
+            '2017-01-04T00:00:00'
         ], dtype='datetime64[ns]')
         curve = Curve((dates_interp, [0, 1, 1, 2, 2, 3, 3]))
         self.assertEqual(interpolated, curve)
@@ -357,10 +357,10 @@ class OperationTests(ComparisonTestCase):
         values = [0, 1, 2, 3]
         interpolated = interpolate_curve(Curve((dates, values)), interpolation='steps-mid')
         dates_interp = np.array([
-            '2017-01-01T00:00:16.364011520', '2017-01-01T11:59:32.195401728',
-            '2017-01-01T11:59:32.195401728', '2017-01-02T12:00:21.297135616',
-            '2017-01-02T12:00:21.297135616', '2017-01-03T12:01:10.398869504',
-            '2017-01-03T12:01:10.398869504', '2017-01-04T00:00:26.230259712'
+            '2017-01-01T00:00:00', '2017-01-01T12:00:00',
+            '2017-01-01T12:00:00', '2017-01-02T12:00:00',
+            '2017-01-02T12:00:00', '2017-01-03T12:00:00',
+            '2017-01-03T12:00:00', '2017-01-04T00:00:00'
         ], dtype='datetime64[ns]')
         curve = Curve((dates_interp, [0, 0, 1, 1, 2, 2, 3, 3]))
         self.assertEqual(interpolated, curve)
@@ -383,10 +383,10 @@ class OperationTests(ComparisonTestCase):
         values = [0, 1, 2, 3]
         interpolated = interpolate_curve(Curve((dates, values)), interpolation='steps-post')
         dates_interp = np.array([
-            '2017-01-01T00:00:16.364011520', '2017-01-02T00:01:05.465745408',
-            '2017-01-02T00:01:05.465745408', '2017-01-02T23:59:37.128525824',
-            '2017-01-02T23:59:37.128525824', '2017-01-04T00:00:26.230259712',
-            '2017-01-04T00:00:26.230259712'
+            '2017-01-01T00:00:00', '2017-01-02T00:00:00',
+            '2017-01-02T00:00:00', '2017-01-03T00:00:00',
+            '2017-01-03T00:00:00', '2017-01-04T00:00:00',
+            '2017-01-04T00:00:00'
         ], dtype='datetime64[ns]')
         curve = Curve((dates_interp, [0, 0, 1, 1, 2, 2, 3]))
         self.assertEqual(interpolated, curve)


### PR DESCRIPTION
When interpolating datetime values in step(), the values where
converted in floating types: this causes a lack of precision in the
computation. Instead, we can do the computation in datetime64[ns].

Fixes #3878