### PR TITLE
Update ErrorBars to have horizontal errorbar

### DIFF
--- a/examples/reference/elements/bokeh/ErrorBars.ipynb
+++ b/examples/reference/elements/bokeh/ErrorBars.ipynb
@@ -33,7 +33,7 @@
    "source": [
     "``ErrorBars`` provide a visual indicator for the variability of the plotted data on a graph. They are usually applied on top of other plots such as scatter, curve or bar plots to indicate the variability in each sample. \n",
     "\n",
-    "``ErrorBars`` may be used to represent symmetric error or asymmetric error. An ``ErrorBars`` Element must have one key dimensions representing the samples along the x-axis and two or three value dimensions representing the value of the sample and positive and negative error values associated with that sample. See the [Tabular Datasets](../../../user_guide/08-Tabular_Datasets.ipynb) user guide for supported data formats, which include arrays, pandas dataframes and dictionaries of arrays."
+    "``ErrorBars`` may be used to represent symmetric error or asymmetric error. An ``ErrorBars`` Element must have one key dimensions representing the samples along the x-axis and two or three value dimensions representing the value of the sample and positive and negative error values associated with that sample or x-axis. See the [Tabular Datasets](../../../user_guide/08-Tabular_Datasets.ipynb) user guide for supported data formats, which include arrays, pandas dataframes and dictionaries of arrays."
    ]
   },
   {
@@ -42,7 +42,7 @@
    "source": [
     "#### Symmetric error\n",
     "\n",
-    "By default the ``ErrorBars`` Element accepts x- and y-coordinates along with a symmetric error value:"
+    "By default the ``ErrorBars`` Element accepts x- and y-coordinates along with a symmetric error value along y-axis:"
    ]
   },
   {
@@ -67,7 +67,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "``ErrorBars`` is a set of x-/y-coordinates with associated error values.  Error values may be either symmetric or asymmetric, and thus can be supplied as an Nx3 or Nx4 array (or any of the alternative constructors Chart Elements allow)."
+    "``ErrorBars`` is a set of x-/y-coordinates with associated error values along y-axis.  Error values may be either symmetric or asymmetric, and thus can be supplied as an Nx3 or Nx4 array (or any of the alternative constructors Chart Elements allow)."
    ]
   },
   {
@@ -84,14 +84,80 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "#### Errors along x-axis"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "``ErrorBars`` can be a set of a set of x-/y-coordinates with associated error values along x-axis. The parameter `horizontal`, when set to `True`, will set supplied errors along x-axis instead of y-axis."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "errors = [(0.1*i, np.sin(0.1*i), np.random.rand()/2) for i in np.linspace(0, 100, 11)]\n",
+    "hv.Curve(errors) * hv.ErrorBars(errors, horizontal=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Errors along x and y axes"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Two `ErrorBars` with orthogonal errors can be composed together to give x and y errorbars"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "yerrors = [(0.1*i, np.sin(0.1*i), np.random.rand()/2, np.random.rand()/4) for i in np.linspace(0, 100, 11)]\n",
+    "xerrors = [(0.1*i, np.sin(0.1*i), np.random.rand()/2, np.random.rand()/4) for i in np.linspace(0, 100, 11)]\n",
+    "\n",
+    "(hv.Curve(yerrors)\n",
+    " * hv.ErrorBars(yerrors, vdims=['y', 'yerrneg', 'yerrpos'])\n",
+    " * hv.ErrorBars(xerrors, vdims=['y', 'xerrneg', 'xerrpos'], horizontal=True)\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "For full documentation and the available style and plot options, use ``hv.help(hv.ErrorBars).``"
    ]
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
    "name": "python",
-   "pygments_lexer": "ipython3"
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.7"
   }
  },
  "nbformat": 4,

--- a/examples/reference/elements/matplotlib/ErrorBars.ipynb
+++ b/examples/reference/elements/matplotlib/ErrorBars.ipynb
@@ -33,7 +33,7 @@
    "source": [
     "``ErrorBars`` provide a visual indicator for the variability of the plotted data on a graph. They are usually applied on top of other plots such as scatter, curve or bar plots to indicate the variability in each sample. \n",
     "\n",
-    "``ErrorBars`` may be used to represent symmetric error or asymmetric error. An ``ErrorBars`` Element must have one key dimensions representing the samples along the x-axis and two or three value dimensions representing the value of the sample and positive and negative error values associated with that sample. See the [Tabular Datasets](../../../user_guide/08-Tabular_Datasets.ipynb) user guide for supported data formats, which include arrays, pandas dataframes and dictionaries of arrays."
+    "``ErrorBars`` may be used to represent symmetric error or asymmetric error. An ``ErrorBars`` Element must have one key dimensions representing the samples along the x-axis and two or three value dimensions representing the value of the sample and positive and negative error values associated with that sample or x-axis. See the [Tabular Datasets](../../../user_guide/08-Tabular_Datasets.ipynb) user guide for supported data formats, which include arrays, pandas dataframes and dictionaries of arrays."
    ]
   },
   {
@@ -42,7 +42,7 @@
    "source": [
     "#### Symmetric error\n",
     "\n",
-    "By default the ``ErrorBars`` Element accepts x- and y-coordinates along with a symmetric error value:"
+    "By default the ``ErrorBars`` Element accepts x- and y-coordinates along with a symmetric error value along y-axis:"
    ]
   },
   {
@@ -67,7 +67,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "``ErrorBars`` is a set of x-/y-coordinates with associated error values.  Error values may be either symmetric or asymmetric, and thus can be supplied as an Nx3 or Nx4 array (or any of the alternative constructors Chart Elements allow)."
+    "``ErrorBars`` is a set of x-/y-coordinates with associated error values along y-axis.  Error values may be either symmetric or asymmetric, and thus can be supplied as an Nx3 or Nx4 array (or any of the alternative constructors Chart Elements allow)."
    ]
   },
   {
@@ -84,14 +84,80 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "#### Errors along x-axis"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "``ErrorBars`` can be a set of a set of x-/y-coordinates with associated error values along x-axis. The parameter `horizontal`, when set to `True`, will set supplied errors along x-axis instead of y-axis."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "errors = [(0.1*i, np.sin(0.1*i), np.random.rand()/2) for i in np.linspace(0, 100, 11)]\n",
+    "hv.Curve(errors) * hv.ErrorBars(errors, horizontal=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Errors along x and y axes"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Two `ErrorBars` with orthogonal errors can be composed together to give x and y errorbars"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "yerrors = [(0.1*i, np.sin(0.1*i), np.random.rand()/2, np.random.rand()/4) for i in np.linspace(0, 100, 11)]\n",
+    "xerrors = [(0.1*i, np.sin(0.1*i), np.random.rand()/2, np.random.rand()/4) for i in np.linspace(0, 100, 11)]\n",
+    "\n",
+    "(hv.Curve(yerrors)\n",
+    " * hv.ErrorBars(yerrors, vdims=['y', 'yerrneg', 'yerrpos'])\n",
+    " * hv.ErrorBars(xerrors, vdims=['y', 'xerrneg', 'xerrpos'], horizontal=True)\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "For full documentation and the available style and plot options, use ``hv.help(hv.ErrorBars).``"
    ]
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
    "name": "python",
-   "pygments_lexer": "ipython3"
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,

--- a/examples/reference/elements/plotly/ErrorBars.ipynb
+++ b/examples/reference/elements/plotly/ErrorBars.ipynb
@@ -8,7 +8,10 @@
     "<dl class=\"dl-horizontal\">\n",
     "  <dt>Title</dt> <dd> ErrorBars Element</dd>\n",
     "  <dt>Dependencies</dt> <dd>Plotly</dd>\n",
-    "  <dt>Backends</dt> <dd><a href='../bokeh/ErrorBars.ipynb'>Bokeh</a></dd> <dd><a href='../matplotlib/ErrorBars.ipynb'>Matplotlib</a></dd> <dd><a href='./ErrorBars.ipynb'>Plotly</a></dd>\n",
+    "  <dt>Backends</dt>\n",
+    "    <dd><a href='./ErrorBars.ipynb'>Plotly</a></dd>\n",
+    "    <dd><a href='../matplotlib/ErrorBars.ipynb'>Matplotlib</a></dd>\n",
+    "    <dd><a href='../bokeh/ErrorBars.ipynb'>Bokeh</a></dd>\n",
     "</dl>\n",
     "</div>"
    ]
@@ -30,7 +33,7 @@
    "source": [
     "``ErrorBars`` provide a visual indicator for the variability of the plotted data on a graph. They are usually applied on top of other plots such as scatter, curve or bar plots to indicate the variability in each sample. \n",
     "\n",
-    "``ErrorBars`` may be used to represent symmetric error or asymmetric error. An ``ErrorBars`` Element must have one key dimensions representing the samples along the x-axis and two or three value dimensions representing the value of the sample and positive and negative error values associated with that sample. See the [Tabular Datasets](../../../user_guide/08-Tabular_Datasets.ipynb) user guide for supported data formats, which include arrays, pandas dataframes and dictionaries of arrays."
+    "``ErrorBars`` may be used to represent symmetric error or asymmetric error. An ``ErrorBars`` Element must have one key dimensions representing the samples along the x-axis and two or three value dimensions representing the value of the sample and positive and negative error values associated with that sample or x-axis. See the [Tabular Datasets](../../../user_guide/08-Tabular_Datasets.ipynb) user guide for supported data formats, which include arrays, pandas dataframes and dictionaries of arrays."
    ]
   },
   {
@@ -39,7 +42,7 @@
    "source": [
     "#### Symmetric error\n",
     "\n",
-    "By default the ``ErrorBars`` Element accepts x- and y-coordinates along with a symmetric error value:"
+    "By default the ``ErrorBars`` Element accepts x- and y-coordinates along with a symmetric error value along y-axis:"
    ]
   },
   {
@@ -64,7 +67,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "``ErrorBars`` is a set of x-/y-coordinates with associated error values.  Error values may be either symmetric or asymmetric, and thus can be supplied as an Nx3 or Nx4 array (or any of the alternative constructors Chart Elements allow)."
+    "``ErrorBars`` is a set of x-/y-coordinates with associated error values along y-axis.  Error values may be either symmetric or asymmetric, and thus can be supplied as an Nx3 or Nx4 array (or any of the alternative constructors Chart Elements allow)."
    ]
   },
   {
@@ -81,16 +84,82 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "#### Errors along x-axis"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "``ErrorBars`` can be a set of a set of x-/y-coordinates with associated error values along x-axis. The parameter `horizontal`, when set to `True`, will set supplied errors along x-axis instead of y-axis."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "errors = [(0.1*i, np.sin(0.1*i), np.random.rand()/2) for i in np.linspace(0, 100, 11)]\n",
+    "hv.Curve(errors) * hv.ErrorBars(errors, horizontal=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Errors along x and y axes"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Two `ErrorBars` with orthogonal errors can be composed together to give x and y errorbars"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "yerrors = [(0.1*i, np.sin(0.1*i), np.random.rand()/2, np.random.rand()/4) for i in np.linspace(0, 100, 11)]\n",
+    "xerrors = [(0.1*i, np.sin(0.1*i), np.random.rand()/2, np.random.rand()/4) for i in np.linspace(0, 100, 11)]\n",
+    "\n",
+    "(hv.Curve(yerrors)\n",
+    " * hv.ErrorBars(yerrors, vdims=['y', 'yerrneg', 'yerrpos'])\n",
+    " * hv.ErrorBars(xerrors, vdims=['y', 'xerrneg', 'xerrpos'], horizontal=True)\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "For full documentation and the available style and plot options, use ``hv.help(hv.ErrorBars).``"
    ]
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
    "name": "python",
-   "pygments_lexer": "ipython3"
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.7"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 2
 }

--- a/holoviews/element/chart.py
+++ b/holoviews/element/chart.py
@@ -117,8 +117,16 @@ class ErrorBars(Chart2dSelectionExpr, Chart):
     """
     ErrorBars is a Chart element representing error bars in a 1D
     coordinate system where the key dimension corresponds to the
-    location along the x-axis and the value dimensions define the
-    location along the y-axis and the symmetric or assymetric spread.
+    location along the x-axis and the first value dimension 
+    corresponds to the location along the y-axis and one or two 
+    extra value dimensions corresponding to the symmetric or 
+    asymetric errors either along x-axis or y-axis. If two value
+    dimensions are given, then the last value dimension will be 
+    taken as symmetric errors. If three value dimensions are given 
+    then the last two value dimensions will be taken as negative and
+    positive errors. By default the errors are defined along y-axis.
+    A parameter `horizontal`, when set `True`, will define the errors
+    along the x-axis.
     """
     group = param.String(default='ErrorBars', constant=True, doc="""
         A string describing the quantity measured by the ErrorBars
@@ -127,6 +135,8 @@ class ErrorBars(Chart2dSelectionExpr, Chart):
     vdims = param.List(default=[Dimension('y'), Dimension('yerror')],
                        bounds=(1, None), constant=True)
 
+    horizontal = param.Boolean(default=False, doc="""
+        Whether the errors are along y-axis (vertical) or x-axis.""")
 
     def range(self, dim, data_range=True, dimension_range=True):
         """Return the lower and upper bounds of values along dimension.
@@ -144,10 +154,11 @@ class ErrorBars(Chart2dSelectionExpr, Chart):
         Returns:
             Tuple containing the lower and upper bound
         """
+        dim_with_err = 0 if self.horizontal else 1
         didx = self.get_dimension_index(dim)
         dim = self.get_dimension(dim)
-        if didx == 1 and data_range and len(self):
-            mean = self.dimension_values(1)
+        if didx == dim_with_err and data_range and len(self):
+            mean = self.dimension_values(didx)
             neg_error = self.dimension_values(2)
             if len(self.dimensions()) > 3:
                 pos_error = self.dimension_values(3)

--- a/holoviews/plotting/bokeh/chart.py
+++ b/holoviews/plotting/bokeh/chart.py
@@ -510,20 +510,21 @@ class ErrorPlot(ColorbarPlot):
         if self.static_source:
             return {}, mapping, style
 
-        base = element.dimension_values(0)
-        ys = element.dimension_values(1)
-        if len(element.vdims) > 2:
-            neg, pos = (element.dimension_values(vd) for vd in element.vdims[1:3])
-            lower, upper = ys-neg, ys+pos
-        else:
-            err = element.dimension_values(2)
-            lower, upper = ys-err, ys+err
-        data = dict(base=base, lower=lower, upper=upper)
+        x_idx, y_idx = (1, 0) if element.horizontal else (0, 1)
+        base = element.dimension_values(x_idx)
+        mean = element.dimension_values(y_idx)
+        neg_error = element.dimension_values(2)
+        pos_idx = 3 if len(element.dimensions()) > 3 else 2
+        pos_error = element.dimension_values(pos_idx)
+        lower = mean - neg_error
+        upper = mean + pos_error
 
-        if self.invert_axes:
+        if element.horizontal ^ self.invert_axes:
             mapping['dimension'] = 'width'
         else:
             mapping['dimension'] = 'height'
+
+        data = dict(base=base, lower=lower, upper=upper)
         self._categorize_data(data, ('base',), element.dimensions())
         return (data, mapping, style)
 

--- a/holoviews/plotting/plotly/chart.py
+++ b/holoviews/plotting/plotly/chart.py
@@ -150,13 +150,14 @@ class ErrorBarsPlot(ChartPlot, ColorbarPlot):
 
     def get_data(self, element, ranges, style):
         x, y = ('y', 'x') if self.invert_axes else ('x', 'y')
+        error_k = 'error_' + x if element.horizontal else 'error_' + y
         neg_error = element.dimension_values(2)
         pos_idx = 3 if len(element.dimensions()) > 3 else 2
         pos_error = element.dimension_values(pos_idx)
-        error_y = dict(type='data', array=pos_error, arrayminus=neg_error)
+        error_v = dict(type='data', array=pos_error, arrayminus=neg_error)
         return [{x: element.dimension_values(0),
                  y: element.dimension_values(1),
-                 'error_'+y: error_y}]
+                 error_k: error_v}]
 
 
 class BarPlot(ElementPlot):

--- a/holoviews/tests/element/testelementranges.py
+++ b/holoviews/tests/element/testelementranges.py
@@ -87,3 +87,15 @@ class ErrorBarsRangeTests(ComparisonTestCase):
         r = ErrorBars(([1, 2, 3], [2, 3, 4], [0.5, 0.5, 0.5]),
                       vdims=[Dimension('y', range=(0., None)), 'yerr']).range(1)
         self.assertEqual(r, (0., 4.5))
+
+    def test_errorbars_range_horizontal(self):
+        r = ErrorBars(([1, 2, 3], [2, 3, 4], [0.5, 0.5, 0.5]),
+                      horizontal=True).range(0)
+        self.assertEqual(r, (0.5, 3.5))
+
+    def test_errorbars_range_explicit_horizontal(self):
+        r = ErrorBars(([1, 2, 3], [2, 3, 4], [0.5, 0.5, 0.5]),
+                      kdims=[Dimension('x', range=(-1, 4.))],
+                      vdims=['y', 'xerr'],
+                      horizontal=True).range(0)
+        self.assertEqual(r, (-1., 4.))


### PR DESCRIPTION
Up until now, the `ErrorBars` element only support conveying errors along y-axis.
This PR will update the element to allow selecting between x- and y-axis for the errorbars.
The main user facing change will be addition of `horizontal` param. Setting this param `True` will set the errors to be along x-axis instead of y-axis.

EDIT:
Objectives

- [x] Element Errorbars keyword argument 'horizontal' and tests
- [x] Update plotting classes to use `horizontal` parameter
  - [x] Matplotlib
  - [x] Bokeh
  - [x] Ploty
- [x] Update guides
  - [x] Matplotlib
  - [x] Bokeh
  - [x] Ploty