### PR TITLE
Add pipeline property to track data lineage

### DIFF
--- a/holoviews/core/accessors.py
+++ b/holoviews/core/accessors.py
@@ -58,7 +58,6 @@ class AccessorPipelineMeta(type):
                                 init_op, call_op
                             ],
                             output_type=type(result),
-                            group=result.group
                         )
                     elif isinstance(result, MultiDimensionalMapping):
                         for key, element in result.items():
@@ -72,7 +71,6 @@ class AccessorPipelineMeta(type):
                                     init_op, call_op, getitem_op
                                 ],
                                 output_type=type(result),
-                                group=element.group
                             )
             finally:
                 if not in_method:

--- a/holoviews/core/accessors.py
+++ b/holoviews/core/accessors.py
@@ -4,6 +4,7 @@ Module for accessor objects for viewable HoloViews objects.
 from __future__ import absolute_import, unicode_literals
 
 from collections import OrderedDict
+import copy
 
 import param
 from param.parameterized import add_metaclass
@@ -30,6 +31,7 @@ class AccessorPipelineMeta(type):
                 # Wrapped object doesn't support the pipeline property
                 return __call__(*args, **kwargs)
 
+            inst_pipeline = copy.copy(inst._obj. _pipeline)
             in_method = inst._obj._in_method
             if not in_method:
                 inst._obj._in_method = True
@@ -39,13 +41,13 @@ class AccessorPipelineMeta(type):
             if not in_method:
                 mode = getattr(inst, 'mode', None)
                 if isinstance(result, Dataset):
-                    result._pipeline = inst._obj._pipeline + [
+                    result._pipeline = inst_pipeline + [
                         (type(inst), [], {'mode': mode}),
                         (__call__, list(args[1:]), kwargs)
                     ]
                 elif isinstance(result, MultiDimensionalMapping):
                     for key, element in result.items():
-                        element._pipeline = inst._obj._pipeline + [
+                        element._pipeline = inst_pipeline + [
                             (type(inst), [], {'mode': mode}),
                             (__call__, list(args[1:]), kwargs),
                             (getattr(type(result), '__getitem__'), [key], {})

--- a/holoviews/core/accessors.py
+++ b/holoviews/core/accessors.py
@@ -23,31 +23,31 @@ class AccessorPipelineMeta(type):
 
     @classmethod
     def pipelined(mcs, __call__):
-        def pipelined_call(*a, **k):
+        def pipelined_call(*args, **kwargs):
             from .data import Dataset, MultiDimensionalMapping
-            inst = a[0]
+            inst = args[0]
             if not hasattr(inst._obj, '_pipeline'):
                 # Wrapped object doesn't support the pipeline property
-                return __call__(*a, **k)
+                return __call__(*args, **kwargs)
 
             in_method = inst._obj._in_method
             if not in_method:
                 inst._obj._in_method = True
 
-            result = __call__(*a, **k)
+            result = __call__(*args, **kwargs)
 
             if not in_method:
                 mode = getattr(inst, 'mode', None)
                 if isinstance(result, Dataset):
                     result._pipeline = inst._obj._pipeline + [
                         (type(inst), [], {'mode': mode}),
-                        (__call__, list(a[1:]), k)
+                        (__call__, list(args[1:]), kwargs)
                     ]
                 elif isinstance(result, MultiDimensionalMapping):
                     for key, element in result.items():
                         element._pipeline = inst._obj._pipeline + [
                             (type(inst), [], {'mode': mode}),
-                            (__call__, list(a[1:]), k),
+                            (__call__, list(args[1:]), kwargs),
                             (getattr(type(result), '__getitem__'), [key], {})
                         ]
                 inst._obj._in_method = False

--- a/holoviews/core/accessors.py
+++ b/holoviews/core/accessors.py
@@ -162,7 +162,7 @@ class Apply(object):
                     mapped.append((k, new_val))
             return self._obj.clone(mapped, link=link_inputs)
 
-        
+
     def aggregate(self, dimensions=None, function=None, spreadfn=None, **kwargs):
         """Applies a aggregate function to all ViewableElements.
 
@@ -226,7 +226,7 @@ class Redim(object):
             list: List of dimensions with replacements applied
         """
         from .dimension import Dimension
-        
+
         replaced = []
         for d in dimensions:
             if d.name in overrides:

--- a/holoviews/core/accessors.py
+++ b/holoviews/core/accessors.py
@@ -53,6 +53,8 @@ class AccessorPipelineMeta(type):
                 inst._obj._in_method = False
             return result
 
+        pipelined_call.__doc__ = __call__.__doc__
+
         return pipelined_call
 
 

--- a/holoviews/core/accessors.py
+++ b/holoviews/core/accessors.py
@@ -26,6 +26,10 @@ class AccessorPipelineMeta(type):
         def pipelined_call(*a, **k):
             from .data import Dataset, MultiDimensionalMapping
             inst = a[0]
+            if not hasattr(inst._obj, '_pipeline'):
+                # Wrapped object doesn't support the pipeline property
+                return __call__(*a, **k)
+
             in_method = inst._obj._in_method
             if not in_method:
                 inst._obj._in_method = True

--- a/holoviews/core/data/__init__.py
+++ b/holoviews/core/data/__init__.py
@@ -213,7 +213,6 @@ class PipelineMeta(ParameterizedMetaclass):
                         result._pipeline = inst_pipeline.instance(
                             operations=inst_pipeline.operations + [op],
                             output_type=type(result),
-                            group=result.group,
                         )
 
                     elif isinstance(result, MultiDimensionalMapping):
@@ -229,7 +228,6 @@ class PipelineMeta(ParameterizedMetaclass):
                                         op, getitem_op
                                     ],
                                     output_type=type(result),
-                                    group=element.group
                                 )
             finally:
                 if not in_method:
@@ -313,7 +311,7 @@ class Dataset(Element):
         )
         self._pipeline = input_pipeline.instance(
             operations=input_pipeline.operations + [init_op],
-            output_type=type(self), group=self.group
+            output_type=type(self),
         )
 
         # Handle initializing the dataset property.

--- a/holoviews/core/data/__init__.py
+++ b/holoviews/core/data/__init__.py
@@ -174,7 +174,7 @@ class DataConversion(object):
 class PipelineMeta(ParameterizedMetaclass):
 
     # Public methods that should not be wrapped
-    blacklist = ['__init__', 'clone', 'execute_pipeline']
+    blacklist = ['__init__', 'clone']
 
     def __new__(mcs, classname, bases, classdict):
 

--- a/holoviews/core/data/__init__.py
+++ b/holoviews/core/data/__init__.py
@@ -174,16 +174,16 @@ class PipelineMeta(ParameterizedMetaclass):
     # Public methods that should not be wrapped
     blacklist = ['__init__', 'clone', 'execute_pipeline']
 
-    def __new__(cls, classname, bases, classdict):
+    def __new__(mcs, classname, bases, classdict):
 
         for method_name in classdict:
             method_fn = classdict[method_name]
-            if method_name in cls.blacklist or method_name.startswith('_'):
+            if method_name in mcs.blacklist or method_name.startswith('_'):
                 continue
             elif isinstance(method_fn, types.FunctionType):
-                classdict[method_name] = cls.pipelined(method_fn)
+                classdict[method_name] = mcs.pipelined(method_fn)
 
-        inst = type.__new__(cls, classname, bases, classdict)
+        inst = type.__new__(mcs, classname, bases, classdict)
         inst._in_method = False
         return inst
 

--- a/holoviews/core/data/__init__.py
+++ b/holoviews/core/data/__init__.py
@@ -186,7 +186,6 @@ class PipelineMeta(ParameterizedMetaclass):
                 classdict[method_name] = mcs.pipelined(method_fn)
 
         inst = type.__new__(mcs, classname, bases, classdict)
-        inst._in_method = False
         return inst
 
     @staticmethod
@@ -255,6 +254,7 @@ class Dataset(Element):
     _kdim_reductions = {}
 
     def __init__(self, data, kdims=None, vdims=None, **kwargs):
+        self._in_method = False
         input_dataset = kwargs.pop('dataset', None)
         input_pipeline = kwargs.pop('pipeline', [])
         if isinstance(data, Element):
@@ -1003,6 +1003,9 @@ argument to specify a selection specification""")
 
             if 'pipeline' not in overrides:
                 overrides['pipeline'] = self._pipeline
+        elif self._in_method:
+            if 'dataset' not in overrides:
+                overrides['dataset'] = self.dataset
 
         new_dataset = super(Dataset, self).clone(
             data, shared_data, new_type, *args, **overrides

--- a/holoviews/core/data/__init__.py
+++ b/holoviews/core/data/__init__.py
@@ -1023,6 +1023,10 @@ argument to specify a selection specification""")
         return super(Dataset, self).map(*args, **kwargs)
     map.__doc__ = LabelledData.map.__doc__
 
+    def relabel(self, *args, **kwargs):
+        return super(Dataset, self).relabel(*args, **kwargs)
+    relabel.__doc__ = LabelledData.relabel.__doc__
+
     @property
     def iloc(self):
         """Returns iloc indexer with support for columnar indexing.

--- a/holoviews/core/data/__init__.py
+++ b/holoviews/core/data/__init__.py
@@ -995,14 +995,14 @@ argument to specify a selection specification""")
             datatypes = [self.interface.datatype] + self.datatype
             overrides['datatype'] = list(util.unique_iterator(datatypes))
 
-        if 'dataset' not in overrides:
-            overrides['dataset'] = self.dataset
-
-        if 'pipeline' not in overrides:
-            overrides['pipeline'] = self._pipeline
-
         if data is None:
             overrides['_validate_vdims'] = False
+
+            if 'dataset' not in overrides:
+                overrides['dataset'] = self.dataset
+
+            if 'pipeline' not in overrides:
+                overrides['pipeline'] = self._pipeline
 
         new_dataset = super(Dataset, self).clone(
             data, shared_data, new_type, *args, **overrides

--- a/holoviews/core/data/__init__.py
+++ b/holoviews/core/data/__init__.py
@@ -193,6 +193,7 @@ class PipelineMeta(ParameterizedMetaclass):
     def pipelined(method):
         def pipelined_fn(*args, **kwargs):
             inst = args[0]
+            inst_pipeline = copy.copy(getattr(inst, '_pipeline', None))
             in_method = inst._in_method
             if not in_method:
                 inst._in_method = True
@@ -201,12 +202,12 @@ class PipelineMeta(ParameterizedMetaclass):
 
             if not in_method:
                 if isinstance(result, Dataset):
-                    result._pipeline = inst._pipeline + [
+                    result._pipeline = inst_pipeline + [
                         (method, list(args[1:]), kwargs)
                     ]
                 elif isinstance(result, MultiDimensionalMapping):
                     for key, element in result.items():
-                        element._pipeline = inst._pipeline + [
+                        element._pipeline = inst_pipeline + [
                             (method, list(args[1:]), kwargs),
                             (getattr(type(result), '__getitem__'), [key], {})
                         ]

--- a/holoviews/core/data/__init__.py
+++ b/holoviews/core/data/__init__.py
@@ -338,9 +338,9 @@ class Dataset(Element):
     @property
     def pipeline(self):
         """
-        List of (function, args, kwargs) tuples that represents the sequence
-        of operations that was used to create this object, starting
-        with the Dataset stored in dataset property
+        Chain operation that evaluates the sequence of operations that was
+        used to create this object, starting with the Dataset stored in
+        dataset property
         """
         return self._pipeline
 

--- a/holoviews/core/data/__init__.py
+++ b/holoviews/core/data/__init__.py
@@ -13,7 +13,9 @@ from param.parameterized import add_metaclass, ParameterizedMetaclass
 
 from .. import util
 from ..accessors import Redim
-from ..dimension import Dimension, process_dimensions, Dimensioned
+from ..dimension import (
+    Dimension, process_dimensions, Dimensioned, LabelledData
+)
 from ..element import Element
 from ..ndmapping import OrderedDict, MultiDimensionalMapping
 from ..spaces import HoloMap, DynamicMap
@@ -1007,12 +1009,15 @@ argument to specify a selection specification""")
 
         return new_dataset
 
+    # Overrides of superclass methods that are needed so that PipelineMeta
+    # will find them to wrap with pipeline support
     def options(self, *args, **kwargs):
-        # Override so that PipelineMeta finds method to wrap it with pipeline
-        # support
         return super(Dataset, self).options(*args, **kwargs)
-
     options.__doc__ = Dimensioned.options.__doc__
+
+    def map(self, *args, **kwargs):
+        return super(Dataset, self).map(*args, **kwargs)
+    map.__doc__ = LabelledData.map.__doc__
 
     @property
     def iloc(self):

--- a/holoviews/core/data/__init__.py
+++ b/holoviews/core/data/__init__.py
@@ -191,23 +191,23 @@ class PipelineMeta(ParameterizedMetaclass):
 
     @staticmethod
     def pipelined(method):
-        def pipelined_fn(*a, **k):
-            inst = a[0]
+        def pipelined_fn(*args, **kwargs):
+            inst = args[0]
             in_method = inst._in_method
             if not in_method:
                 inst._in_method = True
 
-            result = method(*a, **k)
+            result = method(*args, **kwargs)
 
             if not in_method:
                 if isinstance(result, Dataset):
                     result._pipeline = inst._pipeline + [
-                        (method, list(a[1:]), k)
+                        (method, list(args[1:]), kwargs)
                     ]
                 elif isinstance(result, MultiDimensionalMapping):
                     for key, element in result.items():
                         element._pipeline = inst._pipeline + [
-                            (method, list(a[1:]), k),
+                            (method, list(args[1:]), kwargs),
                             (getattr(type(result), '__getitem__'), [key], {})
                         ]
                 inst._in_method = False

--- a/holoviews/core/data/__init__.py
+++ b/holoviews/core/data/__init__.py
@@ -211,6 +211,8 @@ class PipelineMeta(ParameterizedMetaclass):
                 inst._in_method = False
             return result
 
+        pipelined_fn.__doc__ = method.__doc__
+
         return pipelined_fn
 
 

--- a/holoviews/core/data/__init__.py
+++ b/holoviews/core/data/__init__.py
@@ -13,7 +13,7 @@ from param.parameterized import add_metaclass, ParameterizedMetaclass
 
 from .. import util
 from ..accessors import Redim
-from ..dimension import Dimension, process_dimensions
+from ..dimension import Dimension, process_dimensions, Dimensioned
 from ..element import Element
 from ..ndmapping import OrderedDict, MultiDimensionalMapping
 from ..spaces import HoloMap, DynamicMap
@@ -1006,6 +1006,13 @@ argument to specify a selection specification""")
         )
 
         return new_dataset
+
+    def options(self, *args, **kwargs):
+        # Override so that PipelineMeta finds method to wrap it with pipeline
+        # support
+        return super(Dataset, self).options(*args, **kwargs)
+
+    options.__doc__ = Dimensioned.options.__doc__
 
     @property
     def iloc(self):

--- a/holoviews/core/data/interface.py
+++ b/holoviews/core/data/interface.py
@@ -61,7 +61,6 @@ class Accessor(object):
                 )
                 res._pipeline = self.dataset.pipeline.instance(
                     operations=self.dataset.pipeline.operations + [getitem_op],
-                    group=self.dataset.group,
                     output_type=type(self.dataset)
                 )
         finally:

--- a/holoviews/core/data/interface.py
+++ b/holoviews/core/data/interface.py
@@ -46,12 +46,22 @@ class Accessor(object):
 
     def __getitem__(self, index):
         from ..data import Dataset
+        from ...operation.element import method
         self.dataset._in_method = True
         res = self._perform_getitem(self.dataset, index)
         if isinstance(res, Dataset):
-            res._pipeline = self.dataset.pipeline + [
-                (getattr(type(self), '_perform_getitem'), [index], {})
-            ]
+            getitem_op = method.instance(
+                input_type=type(self),
+                output_type=type(self.dataset),
+                method_name='_perform_getitem',
+                args=[index],
+            )
+            res._pipeline = self.dataset.pipeline.instance(
+                operations=self.dataset.pipeline.operations + [getitem_op],
+                group=self.dataset.group,
+                output_type=type(self.dataset)
+            )
+
         self.dataset._in_method = False
         return res
 

--- a/holoviews/core/data/interface.py
+++ b/holoviews/core/data/interface.py
@@ -46,11 +46,13 @@ class Accessor(object):
 
     def __getitem__(self, index):
         from ..data import Dataset
+        self.dataset._in_method = True
         res = self._perform_getitem(self.dataset, index)
         if isinstance(res, Dataset):
             res._pipeline = self.dataset.pipeline + [
                 (getattr(type(self), '_perform_getitem'), [index], {})
             ]
+        self.dataset._in_method = False
         return res
 
     @classmethod

--- a/holoviews/core/data/multipath.py
+++ b/holoviews/core/data/multipath.py
@@ -59,7 +59,7 @@ class MultiInterface(Interface):
             return
 
         from holoviews.element import Polygons
-        ds = cls._inner_dataset_template(dataset)
+        ds = cls._inner_dataset_template(dataset, validate_vdims=vdims)
         for d in dataset.data:
             ds.data = d
             ds.interface.validate(ds, vdims)
@@ -76,7 +76,7 @@ class MultiInterface(Interface):
 
 
     @classmethod
-    def _inner_dataset_template(cls, dataset):
+    def _inner_dataset_template(cls, dataset, validate_vdims=True):
         """
         Returns a Dataset template used as a wrapper around the data
         contained within the multi-interface dataset.
@@ -84,7 +84,8 @@ class MultiInterface(Interface):
         from . import Dataset
         vdims = dataset.vdims if getattr(dataset, 'level', None) is None else []
         return Dataset(dataset.data[0], datatype=cls.subtypes,
-                       kdims=dataset.kdims, vdims=vdims)
+                       kdims=dataset.kdims, vdims=vdims,
+                       _validate_vdims=validate_vdims)
 
     @classmethod
     def dimension_type(cls, dataset, dim):

--- a/holoviews/core/dimension.py
+++ b/holoviews/core/dimension.py
@@ -486,40 +486,7 @@ class LabelledData(param.Parameterized):
         This class also has an id instance attribute, which
         may be set to associate some custom options with the object.
         """
-        from . import Dataset, DataError
         self.data = data
-
-        # Handle initializing the dataset property.
-        self._dataset = None
-        input_dataset = params.pop('dataset', None)
-        if type(self) is Dataset:
-            self._dataset = self
-        elif input_dataset is not None:
-            # Clone dimension info from input dataset with reference to new
-            # data. This way we keep the metadata for all of the dimensions.
-            try:
-                self._dataset = input_dataset.clone(data=self.data)
-            except DataError:
-                # Dataset not compatible with input data
-                pass
-        if self._dataset is None:
-            # Create a default Dataset to wrap input data
-            try:
-                kdims = list(params.get('kdims', []))
-                vdims = list(params.get('vdims', []))
-                dims = kdims + vdims
-                dataset = Dataset(
-                    self.data,
-                    kdims=dims if dims else None
-                )
-                if len(dataset.dimensions()) == 0:
-                    # No dimensions could be auto-detected in data
-                    raise DataError("No dimensions detected")
-                self._dataset = dataset
-            except DataError:
-                # Data not supported by any storage backend. leave _dataset as
-                # None
-                pass
 
         self._id = None
         self.id = id
@@ -541,10 +508,6 @@ class LabelledData(param.Parameterized):
         elif not util.label_sanitizer.allowable(self.label):
             raise ValueError("Supplied label %r contains invalid characters." %
                              self.label)
-
-    @property
-    def dataset(self):
-        return self._dataset
 
     @property
     def id(self):

--- a/holoviews/core/operation.py
+++ b/holoviews/core/operation.py
@@ -132,7 +132,6 @@ class Operation(param.ParameterizedFunction):
                 operations=element_pipeline.operations + [
                     self.instance(**self.p)
                 ],
-                group=ret.group,
             )
         return ret
 

--- a/holoviews/core/operation.py
+++ b/holoviews/core/operation.py
@@ -3,7 +3,6 @@ Operations manipulate Elements, HoloMaps and Layouts, typically for
 the purposes of analysis or visualization.
 """
 import param
-import copy
 from .dimension import ViewableElement
 from .element import Element
 from .layout import Layout

--- a/holoviews/core/operation.py
+++ b/holoviews/core/operation.py
@@ -8,7 +8,7 @@ from .element import Element
 from .layout import Layout
 from .overlay import NdOverlay, Overlay
 from .spaces import Callable, HoloMap
-from . import util
+from . import util, Dataset
 
 
 class Operation(param.ParameterizedFunction):
@@ -121,6 +121,12 @@ class Operation(param.ParameterizedFunction):
         ret = self._process(element, key)
         for hook in self._postprocess_hooks:
             ret = hook(self, ret, **kwargs)
+
+        if isinstance(ret, Dataset) and isinstance(element, Dataset):
+            ret._dataset = element.dataset.clone()
+            ret._pipeline = element.pipeline + [
+                (self.instance(), [], dict(self.p))
+            ]
         return ret
 
 

--- a/holoviews/core/operation.py
+++ b/holoviews/core/operation.py
@@ -120,7 +120,7 @@ class Operation(param.ParameterizedFunction):
         for hook in self._preprocess_hooks:
             kwargs.update(hook(self, element))
 
-        element_pipeline = copy.copy(getattr(element, '_pipeline', None))
+        element_pipeline = getattr(element, '_pipeline', None)
 
         ret = self._process(element, key)
         for hook in self._postprocess_hooks:
@@ -128,9 +128,12 @@ class Operation(param.ParameterizedFunction):
 
         if isinstance(ret, Dataset) and isinstance(element, Dataset):
             ret._dataset = element.dataset.clone()
-            ret._pipeline = element_pipeline + [
-                (self.instance(), [], dict(self.p))
-            ]
+            ret._pipeline = element_pipeline.instance(
+                operations=element_pipeline.operations + [
+                    self.instance(**self.p)
+                ],
+                group=ret.group,
+            )
         return ret
 
 

--- a/holoviews/core/operation.py
+++ b/holoviews/core/operation.py
@@ -3,6 +3,7 @@ Operations manipulate Elements, HoloMaps and Layouts, typically for
 the purposes of analysis or visualization.
 """
 import param
+import copy
 from .dimension import ViewableElement
 from .element import Element
 from .layout import Layout
@@ -118,13 +119,16 @@ class Operation(param.ParameterizedFunction):
         kwargs = {}
         for hook in self._preprocess_hooks:
             kwargs.update(hook(self, element))
+
+        element_pipeline = copy.copy(getattr(element, '_pipeline', None))
+
         ret = self._process(element, key)
         for hook in self._postprocess_hooks:
             ret = hook(self, ret, **kwargs)
 
         if isinstance(ret, Dataset) and isinstance(element, Dataset):
             ret._dataset = element.dataset.clone()
-            ret._pipeline = element.pipeline + [
+            ret._pipeline = element_pipeline + [
                 (self.instance(), [], dict(self.p))
             ]
         return ret

--- a/holoviews/element/chart.py
+++ b/holoviews/element/chart.py
@@ -1,5 +1,4 @@
 import numpy as np
-import copy
 import param
 
 from ..streams import BoundsXY
@@ -225,60 +224,7 @@ class Histogram(Chart):
         elif isinstance(data, tuple) and len(data) == 2 and len(data[0])+1 == len(data[1]):
             data = data[::-1]
 
-        self._operation_kwargs = params.pop('_operation_kwargs', None)
-
-        dataset = params.pop("dataset", None)
         super(Histogram, self).__init__(data, **params)
-
-        if dataset:
-            # Histogram is a special case in which we keep the data from the
-            # input dataset rather than replace it with the element data.
-            # This is so that dataset contains the data needed to reconstruct
-            # the element.
-            self._dataset = dataset.clone()
-
-    def clone(self, data=None, shared_data=True, new_type=None, *args, **overrides):
-        if 'dataset' in overrides:
-            dataset = overrides.pop('dataset', None)
-        else:
-            dataset = self.dataset
-
-        overrides["dataset"] = None
-
-        new_element = super(Histogram, self).clone(
-            data=data,
-            shared_data=shared_data,
-            new_type=new_type,
-            _operation_kwargs=copy.deepcopy(self._operation_kwargs),
-            *args,
-            **overrides
-        )
-
-        if dataset:
-            # Histogram is a special case in which we keep the data from the
-            # input dataset rather than replace it with the element data.
-            # This is so that dataset contains the data needed to reconstruct
-            # the element.
-            new_element._dataset = dataset.clone()
-
-        return new_element
-
-    def select(self, selection_specs=None, **selection):
-        selected = super(Histogram, self).select(
-            selection_specs=selection_specs, **selection
-        )
-
-        if not np.isscalar(selected) and not np.array_equal(selected.data, self.data):
-            # Selection changed histogram bins, so update dataset
-            selection = {
-                dim: sel for dim, sel in selection.items()
-                if dim in self.dimensions()+['selection_mask']
-            }
-
-            if selected._dataset is not None:
-                selected._dataset = self.dataset.select(**selection)
-
-        return selected
 
     def _get_selection_expr_for_stream_value(self, **kwargs):
         from ..util.transform import dim

--- a/holoviews/operation/element.py
+++ b/holoviews/operation/element.py
@@ -140,8 +140,9 @@ class chain(Operation):
         The output type of the chain operation. Must be supplied if
         the chain is to be used as a channel operation.""")
 
-    group = param.String(default='Chain', doc="""
-        The group assigned to the result after having applied the chain.""")
+    group = param.String(default='', doc="""
+        The group assigned to the result after having applied the chain.
+        Defaults to the group produced by the last operation in the chain""")
 
     operations = param.List(default=[], class_=Operation, doc="""
        A list of Operations (or Operation instances)
@@ -153,7 +154,10 @@ class chain(Operation):
             processed = operation.process_element(processed, key,
                                                   input_ranges=self.p.input_ranges)
 
-        return processed.clone(group=self.p.group)
+        if not self.p.group:
+            return processed
+        else:
+            return processed.clone(group=self.p.group)
 
 
 class transform(Operation):

--- a/holoviews/operation/element.py
+++ b/holoviews/operation/element.py
@@ -84,8 +84,38 @@ class factory(Operation):
         By default, if three overlaid Images elements are supplied,
         the corresponding RGB element will be returned. """)
 
+    args = param.List(default=[], doc="""
+            The list of positional argument to pass to the factory""")
+
+    kwargs = param.Dict(default={}, doc="""
+            The dict of keyword arguments to pass to the factory""")
+
     def _process(self, view, key=None):
-        return self.p.output_type(view)
+        return self.p.output_type(view, *self.p.args, **self.p.kwargs)
+
+
+class method(Operation):
+    """
+    Operation that wraps a method call
+    """
+    output_type = param.ClassSelector(class_=type, doc="""
+            The output type of the method operation""")
+
+    input_type = param.ClassSelector(class_=type, doc="""
+            The object type the method is defined on""")
+
+    method_name = param.String(default='__call__', doc="""
+            The method name""")
+
+    args = param.List(default=[], doc="""
+            The list of positional argument to pass to the method""")
+
+    kwargs = param.Dict(default={}, doc="""
+            The dict of keyword arguments to pass to the method""")
+
+    def _process(self, element, key=None):
+        fn = getattr(self.p.input_type, self.p.method_name)
+        return fn(element, *self.p.args, **self.p.kwargs)
 
 
 class chain(Operation):
@@ -112,7 +142,6 @@ class chain(Operation):
 
     group = param.String(default='Chain', doc="""
         The group assigned to the result after having applied the chain.""")
-
 
     operations = param.List(default=[], class_=Operation, doc="""
        A list of Operations (or Operation instances)
@@ -161,7 +190,6 @@ class transform(Operation):
         processed = (img.data if not self.p.operator
                      else self.p.operator(img.data))
         return img.clone(processed, group=self.p.group)
-
 
 
 class image_overlay(Operation):

--- a/holoviews/operation/element.py
+++ b/holoviews/operation/element.py
@@ -656,19 +656,12 @@ class histogram(Operation):
             if self.p.normed in (True, 'integral'):
                 hist *= edges[1]-edges[0]
 
-        # Save off the kwargs needed to reproduce this Histogram later.
-        # We remove the properties that are used as instructions for how to
-        # calculate the bins, and replace those with the explicit list of bin
-        # edges.  This way, not only can we regenerate this exact histogram
-        # from the same data set, but we can also generate a histogram using
-        # a different dataset that will share the exact same bins.
-        exclusions = {'log', 'bin_range', 'num_bins'}
-        params['_operation_kwargs'] = {
-            k: v for k, v in self.p.items() if k not in exclusions
-        }
-        params['_operation_kwargs']['bins'] = list(edges)
+        # Save off the computed bin edges so that if this operation instance
+        # is used to compute another histogram, it will default to the same
+        # bin edges.
+        self.bins = list(edges)
         return Histogram((edges, hist), kdims=[element.get_dimension(selected_dim)],
-                         label=element.label, dataset=element.dataset, **params)
+                         label=element.label, **params)
 
 
 class decimate(Operation):

--- a/holoviews/operation/timeseries.py
+++ b/holoviews/operation/timeseries.py
@@ -17,7 +17,7 @@ class RollingBase(param.Parameterized):
         Whether to set the x-coordinate at the center or right edge
         of the window.""")
 
-    min_periods = param.Integer(default=None, doc="""
+    min_periods = param.Integer(default=None, allow_None=True, doc="""
        Minimum number of observations in window required to have a
        value (otherwise result is NaN).""")
 
@@ -35,7 +35,7 @@ class rolling(Operation,RollingBase):
     Applies a function over a rolling window.
     """
 
-    window_type = param.ObjectSelector(default=None,
+    window_type = param.ObjectSelector(default=None, allow_None=True,
         objects=['boxcar', 'triang', 'blackman', 'hamming', 'bartlett',
                  'parzen', 'bohman', 'blackmanharris', 'nuttall',
                  'barthann', 'kaiser', 'gaussian', 'general_gaussian',
@@ -72,7 +72,7 @@ class resample(Operation):
     """
 
     closed = param.ObjectSelector(default=None, objects=['left', 'right'],
-        doc="Which side of bin interval is closed")
+        doc="Which side of bin interval is closed", allow_None=True)
 
     function = param.Callable(default=np.mean, doc="""
         Function for computing new values out of existing ones.""")

--- a/holoviews/plotting/bokeh/stats.py
+++ b/holoviews/plotting/bokeh/stats.py
@@ -338,7 +338,7 @@ class ViolinPlot(BoxWhiskerPlot):
         if self.clip:
             vdim = vdim(range=self.clip)
             el = el.clone(vdims=[vdim])
-        kde = univariate_kde(el, dimension=vdim, **kwargs)
+        kde = univariate_kde(el, dimension=vdim.name, **kwargs)
         xs, ys = (kde.dimension_values(i) for i in range(2))
         mask = isfinite(ys) & (ys>0) # Mask out non-finite and zero values
         xs, ys = xs[mask], ys[mask]

--- a/holoviews/tests/core/testdatasetproperty.py
+++ b/holoviews/tests/core/testdatasetproperty.py
@@ -709,13 +709,6 @@ class DatashaderTestCase(DatasetPropertyTestCase):
         # Check dataset
         self.assertEqual(img.dataset, self.ds)
 
-        # Check pipeline
-        pipeline = img.pipeline
-        self.assertEqual(len(pipeline), 3)
-        self.assertIs(pipeline[0][0], Dataset)
-        self.assertIs(pipeline[1][0], Curve)
-        self.assertIsInstance(pipeline[2][0], rasterize)
-
         # Execute pipeline
         self.assertEqual(img.execute_pipeline(), img)
         self.assertEqual(img.execute_pipeline(self.ds2), img2)
@@ -731,14 +724,6 @@ class DatashaderTestCase(DatasetPropertyTestCase):
 
         # Check dataset
         self.assertEqual(rgb.dataset, self.ds)
-
-        # Check pipeline
-        pipeline = rgb.pipeline
-        self.assertEqual(len(pipeline), 4)
-        self.assertIs(pipeline[0][0], Dataset)
-        self.assertIs(pipeline[1][0], Curve)
-        self.assertIsInstance(pipeline[2][0], datashade)
-        self.assertIsInstance(pipeline[3][0], dynspread)
 
         # Execute pipeline
         self.assertEqual(rgb.execute_pipeline(), rgb)

--- a/holoviews/tests/core/testdatasetproperty.py
+++ b/holoviews/tests/core/testdatasetproperty.py
@@ -148,6 +148,12 @@ class CloneTestCase(DatasetPropertyTestCase):
         # Execute pipeline
         self.assertEqual(curve.execute_pipeline(), curve)
 
+    def test_clone_new_data(self):
+        # Replacing data during clone resets .dataset
+        ds_clone = self.ds.clone(data=self.ds2.data)
+        self.assertEqual(ds_clone.dataset, self.ds2)
+        self.assertEqual(len(ds_clone.pipeline), 1)
+
 
 class ReindexTestCase(DatasetPropertyTestCase):
     def test_reindex_dataset(self):

--- a/holoviews/tests/core/testdatasetproperty.py
+++ b/holoviews/tests/core/testdatasetproperty.py
@@ -620,13 +620,14 @@ class HistogramTestCase(DatasetPropertyTestCase):
 
         # Check pipeline
         pipeline = sub_hist.pipeline
-        self.assertEqual(len(pipeline), 3)
+        self.assertEqual(len(pipeline), 4)
         self.assertIs(pipeline[0][0], Dataset)
-        self.assertIsInstance(pipeline[1][0], histogram)
-        self.assertTrue(callable(pipeline[2][0]))
-        self.assertEqual(pipeline[2][0].__name__, 'select')
-        self.assertEqual(pipeline[2][1], [])
-        self.assertEqual(pipeline[2][2], {'a': (1, None)})
+        self.assertIs(pipeline[1][0], Apply)
+        self.assertEqual(pipeline[2][0].__name__, '__call__')
+        self.assertIsInstance(pipeline[2][1][0], histogram)
+        self.assertEqual(pipeline[3][0].__name__, 'select')
+        self.assertEqual(pipeline[3][1], [])
+        self.assertEqual(pipeline[3][2], {'a': (1, None)})
 
         # Execute pipeline
         self.assertEqual(sub_hist.execute_pipeline(), sub_hist)
@@ -650,13 +651,14 @@ class HistogramTestCase(DatasetPropertyTestCase):
 
         # Check pipeline
         pipeline = sub_hist.pipeline
-        self.assertEqual(len(pipeline), 3)
+        self.assertEqual(len(pipeline), 4)
         self.assertIs(pipeline[0][0], Dataset)
-        self.assertIsInstance(pipeline[1][0], histogram)
-        self.assertTrue(callable(pipeline[2][0]))
-        self.assertEqual(pipeline[2][0].__name__, 'select')
-        self.assertEqual(pipeline[2][1], [])
-        self.assertEqual(pipeline[2][2], {'a': (1, None), 'b': 100})
+        self.assertIs(pipeline[1][0], Apply)
+        self.assertEqual(pipeline[2][0].__name__, '__call__')
+        self.assertIsInstance(pipeline[2][1][0], histogram)
+        self.assertEqual(pipeline[3][0].__name__, 'select')
+        self.assertEqual(pipeline[3][1], [])
+        self.assertEqual(pipeline[3][2], {'a': (1, None), 'b': 100})
 
         # Execute pipeline
         self.assertEqual(sub_hist.execute_pipeline(), sub_hist)
@@ -667,10 +669,12 @@ class HistogramTestCase(DatasetPropertyTestCase):
 
         # Check pipeline
         pipeline = curve.pipeline
-        self.assertEqual(len(pipeline), 3)
+        self.assertEqual(len(pipeline), 4)
         self.assertIs(pipeline[0][0], Dataset)
-        self.assertIsInstance(pipeline[1][0], histogram)
-        self.assertIs(pipeline[2][0], Curve)
+        self.assertIs(pipeline[1][0], Apply)
+        self.assertEqual(pipeline[2][0].__name__, '__call__')
+        self.assertIsInstance(pipeline[2][1][0], histogram)
+        self.assertIs(pipeline[3][0], Curve)
 
         # Execute pipeline
         self.assertEqual(curve.execute_pipeline(), curve)

--- a/holoviews/tests/core/testdatasetproperty.py
+++ b/holoviews/tests/core/testdatasetproperty.py
@@ -709,6 +709,13 @@ class DatashaderTestCase(DatasetPropertyTestCase):
         # Check dataset
         self.assertEqual(img.dataset, self.ds)
 
+        # Check pipeline
+        pipeline = img.pipeline
+        self.assertEqual(len(pipeline), 3)
+        self.assertIs(pipeline[0][0], Dataset)
+        self.assertIs(pipeline[1][0], Curve)
+        self.assertIsInstance(pipeline[2][0], rasterize)
+
         # Execute pipeline
         self.assertEqual(img.execute_pipeline(), img)
         self.assertEqual(img.execute_pipeline(self.ds2), img2)
@@ -724,6 +731,14 @@ class DatashaderTestCase(DatasetPropertyTestCase):
 
         # Check dataset
         self.assertEqual(rgb.dataset, self.ds)
+
+        # Check pipeline
+        pipeline = rgb.pipeline
+        self.assertEqual(len(pipeline), 4)
+        self.assertIs(pipeline[0][0], Dataset)
+        self.assertIs(pipeline[1][0], Curve)
+        self.assertIsInstance(pipeline[2][0], datashade)
+        self.assertIsInstance(pipeline[3][0], dynspread)
 
         # Execute pipeline
         self.assertEqual(rgb.execute_pipeline(), rgb)

--- a/holoviews/tests/operation/testoperation.py
+++ b/holoviews/tests/operation/testoperation.py
@@ -147,46 +147,6 @@ class OperationTests(ComparisonTestCase):
                          vdims=('x_frequency', 'Frequency'))
         self.assertEqual(op_hist, hist)
 
-    def test_histogram_operation_kwargs(self):
-        points = Points([float(j) for i in range(10) for j in [i] * (2 * i)])
-        op_hist = histogram(
-            points,
-            dimension='y',
-            normed=False,
-            num_bins=10,
-            bin_range=[0, 10],
-        )
-
-        hist = Histogram((
-            [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0],
-            [0, 2, 4, 6, 8, 10, 12, 14, 16, 18]
-        ), vdims=('y_count', 'Count'), kdims='y')
-
-        # Check histogram
-        self.assertEqual(op_hist, hist)
-
-        # Check operation kwargs for histogram generated with operation
-        self.assertEqual(
-            op_hist._operation_kwargs,
-            {'dimension': 'y',
-             'normed': False,
-             'dynamic': False,
-             'bins': [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0]}
-        )
-
-        # Test that operation_kwargs is preserved through clone
-        self.assertEqual(
-            op_hist.clone()._operation_kwargs,
-            {'dimension': 'y',
-             'normed': False,
-             'dynamic': False,
-             'bins': [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0]}
-        )
-
-        # Check that operation kwargs is None for histogram generated directly
-        # from the Histogram constructor
-        self.assertIsNone(hist._operation_kwargs)
-
     @da_skip
     def test_dataset_histogram_dask(self):
         import dask.array as da


### PR DESCRIPTION
## Overview
This PR adds a new `pipeline` property to the `Dataset` class.  This property holds a list of `(function, args, kwargs)` tuples that represent the sequence of operations needed to transform the `Dataset` stored in the `dataset` property into an element equal to current element.

It also adds a new `execute_pipeline` method that can evaluate this sequence of functions on an input dataset.  This makes it possible to reproduce the same sequence of operations on a new Dataset.

## Relationship to other PRs

### dataset property
The `dataset` property was added to the `LabelledData` class in https://github.com/pyviz/holoviews/pull/3919. This PR moves the `dataset` property down to the `Dataset` class, so there is no longer a `dataset` property on, for example, the `Layout` class.  This reduces the scope of where `dataset` and `pipeline` need to be correct / consistent.

### Histogram _operation_kwargs
This PR removes all special cases associated with Histogram elements.  So the `Histogram._operation_kwargs` property added in https://github.com/pyviz/holoviews/pull/3921 has been removed.

### select all dims
In https://github.com/pyviz/holoviews/pull/3924, the `select` method is updated to consider all dimensions in the `Dataset` stored in the element's `dataset` property.  This PR does not do this, and instead provides the `execute_pipeline` method as a more powerful alternative to acheiving the same goal. See examples below.

### link_selections
This PR will become a more powerful foundation for the automatic linked selection support being added in https://github.com/pyviz/holoviews/pull/3951

## Example 1: Points
Create a sample 3-dimensional dataset. x and y are independently drawn from the standard normal distribution and r is calculated to be the radius of each point from the origin.
```python
import numpy as np
import pandas as pd
import holoviews as hv
from holoviews import dim
from holoviews.operation.datashader import rasterize, datashade, dynspread 
hv.extension('bokeh')

np.random.seed(1)
df = pd.DataFrame(np.random.randn(100, 2), columns=['x', 'y'])

# Add radius column
df['r'] = (df.x ** 2 + df.y ** 2) ** 0.5

ds = hv.Dataset(df)
points = ds.to.points(kdims=['x', 'y'], groupby=[])
points
```
![bokeh_plot-1](https://user-images.githubusercontent.com/15064365/65136633-ea14bd80-d9d5-11e9-99eb-cc731df317f4.png)

Display the pipeline for the new `points`  element
```python
points.pipeline
```
```
[(holoviews.core.data.Dataset, [], {}),
 (holoviews.element.geom.Points,  [],  {'label': '', 'kdims': [Dimension('x'), Dimension('y')], 'vdims': []})]
```
Next, create a new points element by running `execute_pipline` on a subset of the dataset stored in `points.dataset`.  Note that it would not be possible to compute this subset using `points.select` directly because it involves the `r` dimensions which is not a key or value dimension of `points`.

```python
points * points.execute_pipeline(points.dataset.select(x=(0, None), r=(0, 1.5))) 
```
![bokeh_plot-2](https://user-images.githubusercontent.com/15064365/65136961-7de68980-d9d6-11e9-9c51-5674c6de877c.png)

## Example 2: Datashade
Create an `RGB` image element from `points` using the `datashade` and `dynspread` operations with `dynamic=False`.

```python
points_rgb = dynspread(datashade(points, dynamic=False), dynamic=False, threshold=0.9)
points_rgb
```
![bokeh_plot-3](https://user-images.githubusercontent.com/15064365/65137074-b0908200-d9d6-11e9-93dc-4b6977927424.png)

Display the pipeline for `points_rgb`

```python
points_rgb.pipeline
```
```
[(holoviews.core.data.Dataset, [], {}),
 (holoviews.element.geom.Points,  [],  {'label': '', 'kdims': [Dimension('x'), Dimension('y')], 'vdims': []}),
 (datashade(...),  [],  {'dynamic': False}),
 (dynspread(...),  [],  {'dynamic': False, 'threshold': 0.9})]
```
Next, compute a new `RGB` element by calling the `execute_pipeline` method with a subset of the original dataset.  Note that this is a selection that was not possible using the approach in https://github.com/pyviz/holoviews/pull/3924.

```python
points_rgb + points_rgb.execute_pipeline(points_rgb.dataset.select(x=(0, None), r=(0, 1.5)))
```
![Screenshot_20190918_054413](https://user-images.githubusercontent.com/15064365/65137458-5f34c280-d9d7-11e9-84f6-9456d52e281f.png)

## Example 3: Histogram
Next, repeat the same process using a `Histogram` element created from `points`.

```python
hist1 = hv.operation.histogram(points, num_bins=10, dynamic=False, normed=False)
hist1
```
![bokeh_plot-4](https://user-images.githubusercontent.com/15064365/65137556-8ee3ca80-d9d7-11e9-8462-251388f60da5.png)

Display pipeline
```python
hist1.pipeline
```
```
[(holoviews.core.data.Dataset, [], {}),
 (holoviews.element.geom.Points,  [],  {'label': '', 'kdims': [Dimension('x'), Dimension('y')], 'vdims': []}),
 (histogram(...),  [],  {'num_bins': 10, 'dynamic': False, 'normed': False})]
```
Create new `Histogram` element with `execute_pipeline`

```python
hist2 = hist1.execute_pipeline(hist1.dataset.select(x=(0, None), r=(0, 1.5))) 
hist1 * hist2
```
![bokeh_plot-5](https://user-images.githubusercontent.com/15064365/65137686-c5214a00-d9d7-11e9-965e-7d5b02b84ab0.png)

## Example 4: Custom aggregation
In this example, create a `Bars` element from the result of aggregating an original `Dataset`.

```python
df = pd.DataFrame({'a': [1, 2, 3, 4, 5, 6],
                   'b': [2, 1, 3, 0, 10, 4],
                   'c': [0, 0, 0, 1, 1, 1]
                  })
ds = hv.Dataset(df, kdims=['c'], vdims=['a', 'b'])
bars = ds.aggregate('c', function=np.sum).to(hv.Bars)
bars
```
![bokeh_plot-6](https://user-images.githubusercontent.com/15064365/65137824-00bc1400-d9d8-11e9-8288-796816e3452a.png)

pipeline
```python
bars.pipeline
```
```
[(holoviews.core.data.Dataset,
  [],
  {'kdims': [Dimension('c')], 'vdims': [Dimension('a'), Dimension('b')]}),
 (<function holoviews.core.data.Dataset.aggregate(...)>,
  ['c'],
  {'function': <function numpy.sum(...)>}),
 (holoviews.element.chart.Bars,
  [],
  {'label': '',
   'kdims': [Dimension('c')],
   'vdims': [Dimension('a'), Dimension('b')]})]
```
Create a new `Bars` element on a subset of the original dataset using `execute_pipeline`

```python
bars * bars.execute_pipeline(bars.dataset.select(b=(3, None)))
```
![bokeh_plot-7](https://user-images.githubusercontent.com/15064365/65137955-36f99380-d9d8-11e9-8fad-f554be6b63ee.png)
