### PR TITLE
Resolve dependent functions in Dynamic operations

### DIFF
--- a/holoviews/util/__init__.py
+++ b/holoviews/util/__init__.py
@@ -921,6 +921,11 @@ class Dynamic(param.ParameterizedFunction):
         for k, v in self.p.kwargs.items():
             if util.is_param_method(v):
                 v = v()
+            elif isinstance(v, FunctionType) and hasattr(v, '_dinfo'):
+                deps = v._dinfo
+                args = (getattr(p.owner, p.name) for p in deps.get('dependencies', []))
+                kwargs = {k: getattr(p.owner, p.name) for k, p in deps.get('kw', {}).items()}
+                v = v(*args, **kwargs)
             evaled_kwargs[k] = v
         return evaled_kwargs
 


### PR DESCRIPTION
This makes it possible to provide a function which declares param dependencies in ``.apply`` and in operations, e.g.:

```python
@pn.depends(field.param.value, agg_fn.param.value)
def aggregator(field, agg_fn):
    field = None if field == "counts" else field
    return agg_fn(field)

datashade(..., agg=aggregator)
# or
obj.apply(datashade, agg=aggregator)
```

This complements the ability to use functions with dependencies as ``DynamicMap`` callbacks.

Cc: @jbednar 