### PR TITLE
Ensure Dynamic utility subscribes to dependent function

### DIFF
--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -9,11 +9,12 @@ import string
 import unicodedata
 import datetime as dt
 
-from distutils.version import LooseVersion as _LooseVersion
-from functools import partial
 from collections import defaultdict
 from contextlib import contextmanager
+from distutils.version import LooseVersion as _LooseVersion
+from functools import partial
 from threading import Thread, Event
+from types import FunctionType
 
 import numpy as np
 import param
@@ -26,7 +27,7 @@ except:
 # Python3 compatibility
 if sys.version_info.major >= 3:
     import builtins as builtins   # noqa (compatibility)
-    
+
     basestring = str
     unicode = str
     long = int
@@ -38,7 +39,7 @@ if sys.version_info.major >= 3:
     LooseVersion = _LooseVersion
 else:
     import __builtin__ as builtins # noqa (compatibility)
-    
+
     basestring = basestring
     unicode = unicode
     from itertools import izip
@@ -1464,6 +1465,35 @@ def is_param_method(obj, has_deps=False):
     if parameterized and has_deps:
         return getattr(obj, "_dinfo", {}).get('dependencies')
     return parameterized
+
+
+def resolve_dependent_kwargs(kwargs):
+    """Resolves parameter dependencies in the supplied dictionary
+
+    Resolves parameter values, Parameterized instance methods and
+    parameterized functions with dependencies in the supplied
+    dictionary.
+
+    Args:
+       kwargs (dict): A dictionary of keyword arguments
+
+    Returns:
+       A new dictionary with where any parameter dependencies have been
+       resolved.
+    """
+    resolved = {}
+    for k, v in kwargs.items():
+        if is_param_method(v, has_deps=True):
+            v = v()
+        elif isinstance(v, param.Parameter) and isinstance(v.owner, param.Parameterized):
+            v = getattr(v.owner, v.name)
+        elif isinstance(v, FunctionType) and hasattr(v, '_dinfo'):
+            deps = v._dinfo
+            args = (getattr(p.owner, p.name) for p in deps.get('dependencies', []))
+            kwargs = {k: getattr(p.owner, p.name) for k, p in deps.get('kw', {}).items()}
+            v = v(*args, **kwargs)
+        resolved[k] = v
+    return resolved
 
 
 @contextmanager

--- a/holoviews/tests/core/testapply.py
+++ b/holoviews/tests/core/testapply.py
@@ -132,6 +132,16 @@ class TestApplyElement(ComparisonTestCase):
         pinst.label = 'Another label'
         self.assertEqual(applied.last, self.element.relabel('Another label!'))
 
+    def test_element_apply_function_with_dependencies_non_dynamic(self):
+        pinst = ParamClass()
+
+        @param.depends(pinst.param.label)
+        def get_label(label):
+            return label + '!'
+
+        applied = self.element.apply('relabel', dynamic=False, label=get_label)
+        self.assertEqual(applied, self.element.relabel('Test!'))
+
     def test_element_apply_dynamic_with_param_method(self):
         pinst = ParamClass()
         applied = self.element.apply(lambda x, label: x.relabel(label), label=pinst.dynamic_label)

--- a/holoviews/util/__init__.py
+++ b/holoviews/util/__init__.py
@@ -898,6 +898,12 @@ class Dynamic(param.ParameterizedFunction):
         for value in self.p.kwargs.values():
             if util.is_param_method(value, has_deps=True):
                 streams.append(value)
+            elif isinstance(value, FunctionType) and hasattr(value, '_dinfo'):
+                dependencies = list(value._dinfo.get('dependencies', []))
+                dependencies += list(value._dinfo.get('kwargs', {}).values())
+                params = [d for d in dependencies if isinstance(d, param.Parameter)
+                          and isinstance(d.owner, param.Parameterized)]
+                streams.append(Params(parameters=params, watch_only=True))
 
         valid, invalid = Stream._process_streams(streams)
         if invalid:


### PR DESCRIPTION
Fixes issue with #3975 

While dependent functions were resolved without this, the DynamicMap did not actually subscribe changes in the dependencies and therefore wouldn't trigger an update until something else changed.