### PR TITLE
Add support for packing grid value dimensions

### DIFF
--- a/holoviews/core/data/grid.py
+++ b/holoviews/core/data/grid.py
@@ -201,6 +201,20 @@ class GridInterface(DictInterface):
 
 
     @classmethod
+    def dtype(cls, dataset, dimension):
+        name = dataset.get_dimension(dimension, strict=True).name
+        vdim_tuple = cls.packed(dataset)
+        if name in vdim_tuple:
+            data = dataset.data[vdim_tuple][..., vdim_tuple.index(name)]
+        else:
+            data = dataset.data[name]
+        if util.isscalar(data):
+            return np.array([data]).dtype
+        else:
+            return data.dtype
+
+
+    @classmethod
     def shape(cls, dataset, gridded=False):
         vdim_tuple = cls.packed(dataset)
         if vdim_tuple:

--- a/holoviews/core/data/grid.py
+++ b/holoviews/core/data/grid.py
@@ -204,7 +204,7 @@ class GridInterface(DictInterface):
     def dtype(cls, dataset, dimension):
         name = dataset.get_dimension(dimension, strict=True).name
         vdim_tuple = cls.packed(dataset)
-        if name in vdim_tuple:
+        if vdim_tuple and name in vdim_tuple:
             data = dataset.data[vdim_tuple][..., vdim_tuple.index(name)]
         else:
             data = dataset.data[name]

--- a/holoviews/core/data/grid.py
+++ b/holoviews/core/data/grid.py
@@ -57,8 +57,15 @@ class GridInterface(DictInterface):
 
         ndims = len(kdims)
         dimensions = [dimension_name(d) for d in kdims+vdims]
+        vdim_tuple = tuple(dimension_name(vd) for vd in vdims)
         if isinstance(data, tuple):
-            data = {d: v for d, v in zip(dimensions, data)}
+            if (len(data) != len(dimensions) and len(data) == (ndims+1) and
+                len(data[-1].shape) == (ndims+1)):
+                value_array = data[-1]
+                data = {d: v for d, v in zip(dimensions, data[:-1])}
+                data[vdim_tuple] = value_array
+            else:
+                data = {d: v for d, v in zip(dimensions, data)}
         elif isinstance(data, list) and data == []:
             data = OrderedDict([(d, []) for d in dimensions])
         elif not any(isinstance(data, tuple(t for t in interface.types if t is not None))
@@ -78,7 +85,14 @@ class GridInterface(DictInterface):
             raise TypeError('GridInterface must be instantiated as a '
                             'dictionary or tuple')
 
-        for dim in kdims+vdims:
+        validate_dims = list(kdims)
+        if vdim_tuple in data:
+            if not isinstance(data[vdim_tuple], get_array_types()):
+                data[vdim_tuple] = np.array(data[vdim_tuple])
+        else:
+            validate_dims += vdims
+
+        for dim in validate_dims:
             name = dimension_name(dim)
             if name not in data:
                 raise ValueError("Values for dimension %s not found" % dim)
@@ -86,7 +100,11 @@ class GridInterface(DictInterface):
                 data[name] = np.array(data[name])
 
         kdim_names = [dimension_name(d) for d in kdims]
-        vdim_names = [dimension_name(d) for d in vdims]
+        if vdim_tuple in data:
+            vdim_names = [vdim_tuple]
+        else:
+            vdim_names = [dimension_name(d) for d in vdims]
+
         expected = tuple([len(data[kd]) for kd in kdim_names])
         irregular_shape = data[kdim_names[0]].shape if kdim_names else ()
         valid_shape = irregular_shape if len(irregular_shape) > 1 else expected[::-1]
@@ -94,6 +112,10 @@ class GridInterface(DictInterface):
         for vdim in vdim_names:
             shape = data[vdim].shape
             error = DataError if len(shape) > 1 else ValueError
+            if vdim_tuple in data:
+                if shape[-1] != len(vdims):
+                    raise error('The shape of the value array does not match the number of value dimensions.')
+                shape = shape[:-1]
             if (not expected and shape == (1,)) or (len(set((shape,)+shapes)) == 1 and len(shape) > 1):
                 # If empty or an irregular mesh
                 pass
@@ -154,7 +176,13 @@ class GridInterface(DictInterface):
 
     @classmethod
     def validate(cls, dataset, vdims=True):
-        Interface.validate(dataset, vdims)
+        dims = 'all' if vdims else 'key'
+        not_found = [d for d in dataset.dimensions(dims, label='name')
+                     if d not in dataset.data]
+        if not_found and tuple(not_found) not in dataset.data:
+            raise DataError("Supplied data does not contain specified "
+                            "dimensions, the following dimensions were "
+                            "not found: %s" % repr(not_found), cls)
 
 
     @classmethod
@@ -167,8 +195,18 @@ class GridInterface(DictInterface):
 
 
     @classmethod
+    def packed(cls, dataset):
+        vdim_tuple = tuple(vd.name for vd in dataset.vdims)
+        return vdim_tuple if vdim_tuple in dataset.data else False
+
+
+    @classmethod
     def shape(cls, dataset, gridded=False):
-        shape = dataset.data[dataset.vdims[0].name].shape
+        vdim_tuple = cls.packed(dataset)
+        if vdim_tuple:
+            shape = dataset.data[vdim_tuple].shape[:-1]
+        else:
+            shape = dataset.data[dataset.vdims[0].name].shape
         if gridded:
             return shape
         else:
@@ -343,7 +381,11 @@ class GridInterface(DictInterface):
     ):
         dim = dataset.get_dimension(dim, strict=True)
         if dim in dataset.vdims or dataset.data[dim.name].ndim > 1:
-            data = dataset.data[dim.name]
+            vdim_tuple = cls.packed(dataset)
+            if vdim_tuple:
+                data = dataset.data[vdim_tuple][..., dataset.vdims.index(dim)]
+            else:
+                data = dataset.data[dim.name]
             data = cls.canonicalize(dataset, data)
             da = dask_array_module()
             if compute and da and isinstance(data, da.Array):
@@ -582,13 +624,21 @@ class GridInterface(DictInterface):
                      for kdim in dataset.kdims if kdim not in kdims)
         da = dask_array_module()
         dropped = []
-        for vdim in dataset.vdims:
-            values = dataset.data[vdim.name]
-            atleast_1d = da.atleast_1d if is_dask(values) else np.atleast_1d
-            try:
-                data[vdim.name] = atleast_1d(function(values, axis=axes, **kwargs))
-            except TypeError:
-                dropped.append(vdim)
+        vdim_tuple = cls.packed(dataset)
+        if vdim_tuple:
+            values = dataset.data[vdim_tuple]
+            if axes:
+                data[vdim_tuple] = function(values, axis=axes, **kwargs)
+            else:
+                data[vdim_tuple] = values
+        else:
+            for vdim in dataset.vdims:
+                values = dataset.data[vdim.name]
+                atleast_1d = da.atleast_1d if is_dask(values) else np.atleast_1d
+                try:
+                    data[vdim.name] = atleast_1d(function(values, axis=axes, **kwargs))
+                except TypeError:
+                    dropped.append(vdim)
         return data, dropped
 
 

--- a/holoviews/core/data/interface.py
+++ b/holoviews/core/data/interface.py
@@ -269,7 +269,7 @@ class Interface(param.Parameterized):
 
     @classmethod
     def isscalar(cls, dataset, dim):
-        return cls.values(dataset, dim, expanded=False) == 1
+        return len(cls.values(dataset, dim, expanded=False)) == 1
 
 
     @classmethod

--- a/holoviews/element/raster.py
+++ b/holoviews/element/raster.py
@@ -734,7 +734,7 @@ class RGB(Image):
             vdims = list(vdims) if isinstance(vdims, list) else [vdims]
 
         alpha = self.alpha_dimension
-        if ((isinstance(data, np.ndarray) and data.shape[-1] == 4 and len(vdims) == 3) or
+        if ((hasattr(data, 'shape') and data.shape[-1] == 4 and len(vdims) == 3) or
             (isinstance(data, tuple) and isinstance(data[-1], np.ndarray) and data[-1].ndim == 3
              and data[-1].shape[-1] == 4 and len(vdims) == 3) or
             (isinstance(data, dict) and tuple(dimension_name(vd) for vd in vdims)+(alpha.name,) in data)):

--- a/holoviews/element/raster.py
+++ b/holoviews/element/raster.py
@@ -4,10 +4,10 @@ import numpy as np
 import colorsys
 import param
 
-from ..core import util, config
+from ..core import util, config, Dimension, Element2D, Overlay, Dataset
 from ..core.data import ImageInterface, GridInterface
 from ..core.data.interface import DataError
-from ..core import Dimension, Element2D, Overlay, Dataset
+from ..core.dimension import dimension_name
 from ..core.boundingregion import BoundingRegion, BoundingBox
 from ..core.sheetcoords import SheetCoordinateSystem, Slice
 from .chart import Curve
@@ -732,9 +732,14 @@ class RGB(Image):
             vdims = list(self.vdims)
         else:
             vdims = list(vdims) if isinstance(vdims, list) else [vdims]
-        if isinstance(data, np.ndarray):
-            if data.shape[-1] == 4 and len(vdims) == 3:
-                vdims.append(self.alpha_dimension)
+
+        alpha = self.alpha_dimension
+        if ((isinstance(data, np.ndarray) and data.shape[-1] == 4 and len(vdims) == 3) or
+            (isinstance(data, tuple) and isinstance(data[-1], np.ndarray) and data[-1].ndim == 3
+             and data[-1].shape[-1] == 4 and len(vdims) == 3) or
+            (isinstance(data, dict) and tuple(dimension_name(vd) for vd in vdims)+(alpha.name,) in data)):
+            # Handle all forms of packed value dimensions
+            vdims.append(alpha)
         super(RGB, self).__init__(data, kdims=kdims, vdims=vdims, **params)
 
 

--- a/holoviews/plotting/bokeh/raster.py
+++ b/holoviews/plotting/bokeh/raster.py
@@ -157,6 +157,8 @@ class RGBPlot(ElementPlot):
                 img = np.dstack([img, alpha])
             N, M, _ = img.shape
             #convert image NxM dtype=uint32
+            if not img.flags['C_CONTIGUOUS']:
+                img = img.copy()
             img = img.view(dtype=np.uint32).reshape((N, M))
 
         # Ensure axis inversions are handled correctly

--- a/holoviews/tests/core/data/testgridinterface.py
+++ b/holoviews/tests/core/data/testgridinterface.py
@@ -606,6 +606,15 @@ class RGB_GridInterfaceTests(RGB_ImageInterfaceTests):
                         self.rgb_array[:, :, 1], self.rgb_array[:, :, 2]))
 
 
+class RGB_PackedGridInterfaceTests(RGB_ImageInterfaceTests):
+
+    datatype = 'grid'
+    data_type = OrderedDict
+
+    def init_data(self):
+        self.rgb = RGB((self.xs, self.ys, self.rgb_array))
+
+
 class HSV_GridInterfaceTests(HSV_ImageInterfaceTests):
 
     datatype = 'grid'

--- a/holoviews/tests/core/data/testxarrayinterface.py
+++ b/holoviews/tests/core/data/testxarrayinterface.py
@@ -373,6 +373,15 @@ class RGB_XArrayInterfaceTests(RGB_ImageInterfaceTests):
                         self.rgb_array[:, :, 1], self.rgb_array[:, :, 2]))
 
 
+class RGB_PackedXArrayInterfaceTests(RGB_ImageInterfaceTests):
+
+    datatype = 'xarray'
+    data_type = xr.Dataset
+
+    def init_data(self):
+        self.rgb = RGB((self.xs, self.ys, self.rgb_array))
+        
+
 class HSV_XArrayInterfaceTest(HSV_ImageInterfaceTests):
 
     datatype = 'xarray'

--- a/holoviews/tests/element/testraster.py
+++ b/holoviews/tests/element/testraster.py
@@ -3,7 +3,7 @@ Unit tests of Raster elements
 """
 
 import numpy as np
-from holoviews.element import Raster, Image, Curve, QuadMesh
+from holoviews.element import Raster, Image, Curve, QuadMesh, RGB
 from holoviews.element.comparison import ComparisonTestCase
 
 class TestRaster(ComparisonTestCase):
@@ -31,6 +31,23 @@ class TestRaster(ComparisonTestCase):
         self.assertEqual(rrange, (np.min(arr), np.max(arr)))
 
 
+def TestRGB(ComparisonTestCase):
+
+    def setUp(ComparisonTestCase):
+        self.rgb_array = np.random.randint(0, 255, (3, 3, 4))
+
+    def test_construct_from_array_with_alpha(self):
+        rgb = RGB(self.rgb_array)
+        self.assertEqual(len(rgb.vdims), 4)
+
+    def test_construct_from_tuple_with_alpha(self):
+        rgb = RGB(([0, 1, 2], [0, 1, 2], self.rgb_array))
+        self.assertEqual(len(rgb.vdims), 4)
+    
+    def test_construct_from_dict_with_alpha(self):
+        rgb = RGB({'x': [1, 2, 3], 'y': [1, 2, 3], ('R', 'G', 'B', 'A'): self.rgb_array})
+        self.assertEqual(len(rgb.vdims), 4)
+        
 
 class TestQuadMesh(ComparisonTestCase):
 

--- a/holoviews/tests/element/testraster.py
+++ b/holoviews/tests/element/testraster.py
@@ -31,9 +31,9 @@ class TestRaster(ComparisonTestCase):
         self.assertEqual(rrange, (np.min(arr), np.max(arr)))
 
 
-def TestRGB(ComparisonTestCase):
+class TestRGB(ComparisonTestCase):
 
-    def setUp(ComparisonTestCase):
+    def setUp(self):
         self.rgb_array = np.random.randint(0, 255, (3, 3, 4))
 
     def test_construct_from_array_with_alpha(self):


### PR DESCRIPTION
This PR makes it possible to construct gridded datasets where all the value dimensions are packed into a single array. This is often a much more natural format, e.g. for an RGB:

```
hv.RGB(([1, 2, 3], [1, 2, 3], np.random.rand(3, 3, 3)))
# or equivalently
hv.RGB({'x': [1, 2, 3], 'y': [1, 2, 3], ('R', 'G', 'B'): np.random.rand(3, 3, 3)})
```

Also adds support for packed value dimensions on xr.DataArray types:

```python 
da = xr.DataArray(data=np.random.randint(0, 255, (2, 2, 4)), dims=('x', 'y', 'band'), coords={'x': [1, 2], 'y': [1, 2], 'band': [0, 1, 2, 3]})
hv.RGB(da)
```

Closes https://github.com/pyviz/holoviews/issues/550
Closes https://github.com/pyviz/holoviews/issues/3311