### PR TITLE
Add new annotations, HSpan, VSpan

### DIFF
--- a/examples/reference/elements/bokeh/HLine.ipynb
+++ b/examples/reference/elements/bokeh/HLine.ipynb
@@ -4,16 +4,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<div class=\"contentcontainer med left\" style=\"margin-left: -50px;\">\n",
-    "<dl class=\"dl-horizontal\">\n",
-    "  <dt>Title</dt> <dd> HLine Element</dd>\n",
-    "  <dt>Dependencies</dt> <dd>Bokeh</dd>\n",
-    "  <dt>Backends</dt>\n",
-    "    <dd><a href='./HLine.ipynb'>Bokeh</a></dd>\n",
-    "    <dd><a href='../matplotlib/HLine.ipynb'>Matplotlib</a></dd>\n",
-    "    <dd><a href='../plotly/HLine.ipynb'>Plotly</a></dd>\n",
-    "</dl>\n",
-    "</div>"
+    "#### **Title**: HLine Element\n",
+    "\n",
+    "**Dependencies**: Bokeh\n",
+    "\n",
+    "**Backends**: [Matplotlib](../matplotlib/HLine.ipynb), [Bokeh](./HLine.ipynb)"
    ]
   },
   {
@@ -64,5 +59,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/examples/reference/elements/bokeh/HSpan.ipynb
+++ b/examples/reference/elements/bokeh/HSpan.ipynb
@@ -1,0 +1,82 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### **Title**: HSpan Element\n",
+    "\n",
+    "**Dependencies**: Bokeh\n",
+    "\n",
+    "**Backends**: [Matplotlib](../matplotlib/HSpan.ipynb), [Bokeh](./HSpan.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import holoviews as hv\n",
+    "from holoviews import opts\n",
+    "hv.extension('bokeh')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The ``HSpan`` element is a type of annotation that marks a range along the y-axis. Here is an ``HSpan`` element that marks the standard deviation in a collection of points:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "xs = np.random.normal(size=500)\n",
+    "ys = np.random.normal(size=500) * xs\n",
+    "ymean, ystd = ys.mean(), ys.std()\n",
+    "\n",
+    "points = hv.Points((xs,ys))\n",
+    "hspan  = hv.HSpan(ymean-ystd, ymean+ystd)\n",
+    "\n",
+    "hspan.opts(color='blue') * points.opts(color='#D3D3D3')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Like all annotation-like elements `HSpan` is not included in the calculation of axis ranges by default, but can be included by setting `apply_ranges=True`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "(hv.HSpan(1, 3) * hv.HSpan(5, 8)).opts(\n",
+    "    opts.HSpan(apply_ranges=True))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For full documentation and the available style and plot options, use ``hv.help(hv.HSpan).``"
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/examples/reference/elements/bokeh/HSpan.ipynb
+++ b/examples/reference/elements/bokeh/HSpan.ipynb
@@ -8,7 +8,7 @@
     "\n",
     "**Dependencies**: Bokeh\n",
     "\n",
-    "**Backends**: [Matplotlib](../matplotlib/HSpan.ipynb), [Bokeh](./HSpan.ipynb)"
+    "**Backends**: [Matplotlib](../matplotlib/HSpan.ipynb), [Plotly](../plotly/HSpan.ipynb), [Bokeh](./HSpan.ipynb)"
    ]
   },
   {
@@ -20,6 +20,7 @@
     "import numpy as np\n",
     "import holoviews as hv\n",
     "from holoviews import opts\n",
+    "\n",
     "hv.extension('bokeh')"
    ]
   },

--- a/examples/reference/elements/bokeh/VLine.ipynb
+++ b/examples/reference/elements/bokeh/VLine.ipynb
@@ -4,16 +4,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<div class=\"contentcontainer med left\" style=\"margin-left: -50px;\">\n",
-    "<dl class=\"dl-horizontal\">\n",
-    "  <dt>Title</dt> <dd> VLine Element</dd>\n",
-    "  <dt>Dependencies</dt> <dd>Bokeh</dd>\n",
-    "  <dt>Backends</dt>\n",
-    "    <dd><a href='./VLine.ipynb'>Bokeh</a></dd>\n",
-    "    <dd><a href='../matplotlib/VLine.ipynb'>Matplotlib</a></dd>\n",
-    "    <dd><a href='../plotly/VLine.ipynb'>Plotly</a></dd>\n",
-    "</dl>\n",
-    "</div>"
+    "#### **Title**: VLine Element\n",
+    "\n",
+    "**Dependencies**: Bokeh\n",
+    "\n",
+    "**Backends**: [Matplotlib](../matplotlib/VLine.ipynb), [Bokeh](./VLine.ipynb)"
    ]
   },
   {
@@ -64,5 +59,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/examples/reference/elements/bokeh/VSpan.ipynb
+++ b/examples/reference/elements/bokeh/VSpan.ipynb
@@ -8,7 +8,7 @@
     "\n",
     "**Dependencies**: Bokeh\n",
     "\n",
-    "**Backends**: [Matplotlib](../matplotlib/VSpan.ipynb), [Bokeh](./VSpan.ipynb)"
+    "**Backends**: [Matplotlib](../matplotlib/VSpan.ipynb), [Plotly](../plotly/VSpan.ipynb), [Bokeh](./VSpan.ipynb)"
    ]
   },
   {

--- a/examples/reference/elements/bokeh/VSpan.ipynb
+++ b/examples/reference/elements/bokeh/VSpan.ipynb
@@ -1,0 +1,82 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### **Title**: VSpan Element\n",
+    "\n",
+    "**Dependencies**: Bokeh\n",
+    "\n",
+    "**Backends**: [Matplotlib](../matplotlib/VSpan.ipynb), [Bokeh](./VSpan.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import holoviews as hv\n",
+    "from holoviews import opts\n",
+    "hv.extension('bokeh')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The ``VSpan`` element is a type of annotation that marks a range along the x-axis. Here is a ``VSpan`` marking maximum region of a quadratic curve:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "xs = np.linspace(-5, 5, 100)\n",
+    "ys = -(xs-2)**2\n",
+    "ymax = ys.argmax()\n",
+    "\n",
+    "curve = hv.Curve((xs,ys))\n",
+    "vspan = hv.VSpan(xs[ymax-5], xs[ymax+5])\n",
+    "\n",
+    "curve.opts(color='#D3D3D3') * vspan.opts(color='red')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Like all annotation-like elements `VSpan` is not included in the calculation of axis ranges by default, but can be included by setting `apply_ranges=True`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "(hv.VSpan(1, 3) * hv.VSpan(5, 8)).opts(\n",
+    "    opts.VSpan(apply_ranges=True))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For full documentation and the available style and plot options, use ``hv.help(hv.VSpan).``"
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/examples/reference/elements/matplotlib/HLine.ipynb
+++ b/examples/reference/elements/matplotlib/HLine.ipynb
@@ -4,16 +4,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<div class=\"contentcontainer med left\" style=\"margin-left: -50px;\">\n",
-    "<dl class=\"dl-horizontal\">\n",
-    "  <dt>Title</dt> <dd> HLine Element</dd>\n",
-    "  <dt>Dependencies</dt> <dd>Matplotlib</dd>\n",
-    "  <dt>Backends</dt>\n",
-    "    <dd><a href='./HLine.ipynb'>Matplotlib</a></dd>\n",
-    "    <dd><a href='../bokeh/HLine.ipynb'>Bokeh</a></dd>\n",
-    "    <dd><a href='../plotly/HLine.ipynb'>Plotly</a></dd>\n",
-    "</dl>\n",
-    "</div>"
+    "#### **Title**: HLine Element\n",
+    "\n",
+    "**Dependencies**: Matplotlib\n",
+    "\n",
+    "**Backends**: [Bokeh](../bokeh/HLine.ipynb), [Matplotlib](./HLine.ipynb)"
    ]
   },
   {
@@ -66,5 +61,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/examples/reference/elements/matplotlib/HSpan.ipynb
+++ b/examples/reference/elements/matplotlib/HSpan.ipynb
@@ -1,0 +1,82 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### **Title**: HSpan Element\n",
+    "\n",
+    "**Dependencies**: Matplotlib\n",
+    "\n",
+    "**Backends**: [Bokeh](../bokeh/HSpan.ipynb), [Matplotlib](./HSpan.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import holoviews as hv\n",
+    "from holoviews import opts\n",
+    "hv.extension('matplotlib')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The ``HSpan`` element is a type of annotation that marks a range along the y-axis. Here is an ``HSpan`` element that marks the standard deviation in a collection of points:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "xs = np.random.normal(size=500)\n",
+    "ys = np.random.normal(size=500) * xs\n",
+    "ymean, ystd = ys.mean(), ys.std()\n",
+    "\n",
+    "points = hv.Points((xs,ys))\n",
+    "hspan  = hv.HSpan(ymean-ystd, ymean+ystd)\n",
+    "\n",
+    "hspan.opts(facecolor='blue') * points.opts(color='#D3D3D3')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Like all annotation-like elements `HSpan` is not included in the calculation of axis ranges by default, but can be included by setting `apply_ranges=True`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "(hv.HSpan(1, 3) * hv.HSpan(5, 8)).opts(\n",
+    "    opts.HSpan(apply_ranges=True))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For full documentation and the available style and plot options, use ``hv.help(hv.HSpan).``"
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/examples/reference/elements/matplotlib/VLine.ipynb
+++ b/examples/reference/elements/matplotlib/VLine.ipynb
@@ -4,16 +4,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<div class=\"contentcontainer med left\" style=\"margin-left: -50px;\">\n",
-    "<dl class=\"dl-horizontal\">\n",
-    "  <dt>Title</dt> <dd> VLine Element</dd>\n",
-    "  <dt>Dependencies</dt> <dd>Matplotlib</dd>\n",
-    "  <dt>Backends</dt>\n",
-    "    <dd><a href='./VLine.ipynb'>Matplotlib</a></dd>\n",
-    "    <dd><a href='../bokeh/VLine.ipynb'>Bokeh</a></dd>\n",
-    "    <dd><a href='../plotly/VLine.ipynb'>Plotly</a></dd>\n",
-    "</dl>\n",
-    "</div>"
+    "#### **Title**: VLine Element\n",
+    "\n",
+    "**Dependencies**: Matplotlib\n",
+    "\n",
+    "**Backends**: [Bokeh](../bokeh/VLine.ipynb), [Matplotlib](./VLine.ipynb)"
    ]
   },
   {
@@ -66,5 +61,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/examples/reference/elements/matplotlib/VSpan.ipynb
+++ b/examples/reference/elements/matplotlib/VSpan.ipynb
@@ -1,0 +1,83 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### **Title**: VSpan Element\n",
+    "\n",
+    "**Dependencies**: Matplotlib\n",
+    "\n",
+    "**Backends**: [Bokeh](../bokeh/VSpan.ipynb), [Matplotlib](./VSpan.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import holoviews as hv\n",
+    "from holoviews import opts\n",
+    "\n",
+    "hv.extension('matplotlib')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The ``VSpan`` element is a type of annotation that marks a range along the x-axis. Here is a ``VSpan`` marking maximum region of a quadratic curve:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "xs = np.linspace(-5, 5, 100)\n",
+    "ys = -(xs-2)**2\n",
+    "ymax = ys.argmax()\n",
+    "\n",
+    "curve = hv.Curve((xs,ys))\n",
+    "vspan = hv.VSpan(xs[ymax-5], xs[ymax+5])\n",
+    "\n",
+    "curve.opts(color='#D3D3D3') * vspan.opts(facecolor='red')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Like all annotation-like elements `VSpan` is not included in the calculation of axis ranges by default, but can be included by setting `apply_ranges=True`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "(hv.VSpan(1, 3) * hv.VSpan(5, 8)).opts(\n",
+    "    opts.VSpan(apply_ranges=True))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For full documentation and the available style and plot options, use ``hv.help(hv.VSpan).``"
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/examples/reference/elements/plotly/HSpan.ipynb
+++ b/examples/reference/elements/plotly/HSpan.ipynb
@@ -6,9 +6,9 @@
    "source": [
     "#### **Title**: HSpan Element\n",
     "\n",
-    "**Dependencies**: Matplotlib\n",
+    "**Dependencies**: Plotly\n",
     "\n",
-    "**Backends**: [Bokeh](../bokeh/HSpan.ipynb), [Plotly](../plotly/HSpan.ipynb), [Matplotlib](./HSpan.ipynb)"
+    "**Backends**: [Bokeh](../bokeh/HSpan.ipynb), [Matplotlib](../matplotlib/HSpan.ipynb), [Plotly](./HSpan.ipynb)"
    ]
   },
   {
@@ -20,8 +20,7 @@
     "import numpy as np\n",
     "import holoviews as hv\n",
     "from holoviews import opts\n",
-    "\n",
-    "hv.extension('matplotlib')"
+    "hv.extension('plotly')"
    ]
   },
   {
@@ -44,7 +43,7 @@
     "points = hv.Points((xs,ys))\n",
     "hspan  = hv.HSpan(ymean-ystd, ymean+ystd)\n",
     "\n",
-    "hspan.opts(facecolor='blue') * points.opts(color='#D3D3D3')"
+    "hspan.opts(fillcolor='blue') * points.opts(color='#D3D3D3')"
    ]
   },
   {

--- a/examples/reference/elements/plotly/VSpan.ipynb
+++ b/examples/reference/elements/plotly/VSpan.ipynb
@@ -6,9 +6,9 @@
    "source": [
     "#### **Title**: VSpan Element\n",
     "\n",
-    "**Dependencies**: Matplotlib\n",
+    "**Dependencies**: Plotly\n",
     "\n",
-    "**Backends**: [Bokeh](../bokeh/VSpan.ipynb), [Plotly](../plotly/VSpan.ipynb), [Matplotlib](./VSpan.ipynb)"
+    "**Backends**: [Bokeh](../bokeh/VSpan.ipynb), [Matplotlib](../matplotlib/VSpan.ipynb), [Plotly](./VSpan.ipynb)"
    ]
   },
   {
@@ -21,7 +21,7 @@
     "import holoviews as hv\n",
     "from holoviews import opts\n",
     "\n",
-    "hv.extension('matplotlib')"
+    "hv.extension('plotly')"
    ]
   },
   {
@@ -44,7 +44,7 @@
     "curve = hv.Curve((xs,ys))\n",
     "vspan = hv.VSpan(xs[ymax-5], xs[ymax+5])\n",
     "\n",
-    "curve.opts(color='#D3D3D3') * vspan.opts(facecolor='red')"
+    "curve.opts(color='#D3D3D3') * vspan.opts(fillcolor='red')"
    ]
   },
   {

--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -911,7 +911,9 @@ def find_range(values, soft_range=[]):
             values = np.concatenate([values, soft_range])
         if values.dtype.kind == 'M':
             return values.min(), values.max()
-        return np.nanmin(values), np.nanmax(values)
+        with warnings.catch_warnings():
+            warnings.filterwarnings('ignore', r'All-NaN (slice|axis) encountered')
+            return np.nanmin(values), np.nanmax(values)
     except:
         try:
             values = sorted(values)

--- a/holoviews/element/annotation.py
+++ b/holoviews/element/annotation.py
@@ -89,7 +89,7 @@ class VLine(Annotation):
 
     group = param.String(default='VLine', constant=True)
 
-    x = param.ClassSelector(default=0, class_=(Number, ) + datetime_types, doc="""
+    x = param.ClassSelector(default=0, class_=(Number,) + datetime_types, doc="""
        The x-position of the VLine which make be numeric or a timestamp.""")
 
     __pos_params = ['x']
@@ -112,7 +112,7 @@ class VLine(Annotation):
         if index == 0:
             return np.array([self.data])
         elif index == 1:
-            return np.array([])
+            return np.array([np.nan])
         else:
             return super(VLine, self).dimension_values(dimension)
 
@@ -122,7 +122,7 @@ class HLine(Annotation):
 
     group = param.String(default='HLine', constant=True)
 
-    y = param.ClassSelector(default=0, class_=(Number, ) + datetime_types, doc="""
+    y = param.ClassSelector(default=0, class_=(Number,) + datetime_types, doc="""
        The y-position of the HLine which make be numeric or a timestamp.""")
 
     __pos_params = ['y']
@@ -143,11 +143,12 @@ class HLine(Annotation):
         """
         index = self.get_dimension_index(dimension)
         if index == 0:
-            return np.array([])
+            return np.array([np.nan])
         elif index == 1:
             return np.array([self.data])
         else:
             return super(HLine, self).dimension_values(dimension)
+
 
 
 class VSpan(Annotation):
@@ -155,10 +156,10 @@ class VSpan(Annotation):
 
     group = param.String(default='VSpan', constant=True)
 
-    x1 = param.ClassSelector(default=0, class_=(Number, ) + datetime_types, doc="""
+    x1 = param.ClassSelector(default=0, class_=(Number,) + datetime_types, doc="""
        The start x-position of the VSpan which must be numeric or a timestamp.""")
 
-    x2 = param.ClassSelector(default=0, class_=(Number, ) + datetime_types, doc="""
+    x2 = param.ClassSelector(default=0, class_=(Number,) + datetime_types, doc="""
        The end x-position of the VSpan which must be numeric or a timestamp.""")
 
     __pos_params = ['x1', 'x2']
@@ -179,9 +180,9 @@ class VSpan(Annotation):
         """
         index = self.get_dimension_index(dimension)
         if index == 0:
-            return np.array([self.data])
+            return np.array(self.data)
         elif index == 1:
-            return np.array([])
+            return np.array([np.nan, np.nan])
         else:
             return super(VSpan, self).dimension_values(dimension)
 
@@ -191,10 +192,10 @@ class HSpan(Annotation):
 
     group = param.String(default='HSpan', constant=True)
 
-    y1 = param.ClassSelector(default=0, class_=(Number, ) + datetime_types, doc="""
+    y1 = param.ClassSelector(default=0, class_=(Number,) + datetime_types, doc="""
        The start y-position of the VSpan which must be numeric or a timestamp.""")
 
-    y2 = param.ClassSelector(default=0, class_=(Number, ) + datetime_types, doc="""
+    y2 = param.ClassSelector(default=0, class_=(Number,) + datetime_types, doc="""
        The end y-position of the VSpan which must be numeric or a timestamp.""")
 
     __pos_params = ['y1', 'y2']
@@ -215,11 +216,12 @@ class HSpan(Annotation):
         """
         index = self.get_dimension_index(dimension)
         if index == 0:
-            return np.array([self.data])
+            return np.array([np.nan, np.nan])
         elif index == 1:
-            return np.array([])
+            return np.array(self.data)
         else:
             return super(HSpan, self).dimension_values(dimension)
+
 
 
 class Spline(Annotation):

--- a/holoviews/element/annotation.py
+++ b/holoviews/element/annotation.py
@@ -123,7 +123,7 @@ class HLine(Annotation):
     group = param.String(default='HLine', constant=True)
 
     y = param.ClassSelector(default=0, class_=(Number, ) + datetime_types, doc="""
-       The y-position of the VLine which make be numeric or a timestamp.""")
+       The y-position of the HLine which make be numeric or a timestamp.""")
 
     __pos_params = ['y']
 
@@ -149,6 +149,77 @@ class HLine(Annotation):
         else:
             return super(HLine, self).dimension_values(dimension)
 
+
+class VSpan(Annotation):
+    """Vertical span annotation at the given position."""
+
+    group = param.String(default='VSpan', constant=True)
+
+    x1 = param.ClassSelector(default=0, class_=(Number, ) + datetime_types, doc="""
+       The start x-position of the VSpan which must be numeric or a timestamp.""")
+
+    x2 = param.ClassSelector(default=0, class_=(Number, ) + datetime_types, doc="""
+       The end x-position of the VSpan which must be numeric or a timestamp.""")
+
+    __pos_params = ['x1', 'x2']
+
+    def __init__(self, x1, x2, **params):
+        super(VSpan, self).__init__([x1, x2], **params)
+
+    def dimension_values(self, dimension, expanded=True, flat=True):
+        """Return the values along the requested dimension.
+
+        Args:
+            dimension: The dimension to return values for
+            expanded (bool, optional): Whether to expand values
+            flat (bool, optional): Whether to flatten array
+
+        Returns:
+            NumPy array of values along the requested dimension
+        """
+        index = self.get_dimension_index(dimension)
+        if index == 0:
+            return np.array([self.data])
+        elif index == 1:
+            return np.array([])
+        else:
+            return super(VSpan, self).dimension_values(dimension)
+
+
+class HSpan(Annotation):
+    """Horziontal span annotation at the given position."""
+
+    group = param.String(default='HSpan', constant=True)
+
+    y1 = param.ClassSelector(default=0, class_=(Number, ) + datetime_types, doc="""
+       The start y-position of the VSpan which must be numeric or a timestamp.""")
+
+    y2 = param.ClassSelector(default=0, class_=(Number, ) + datetime_types, doc="""
+       The end y-position of the VSpan which must be numeric or a timestamp.""")
+
+    __pos_params = ['y1', 'y2']
+
+    def __init__(self, y1, y2, **params):
+        super(HSpan, self).__init__([y1, y2], **params)
+
+    def dimension_values(self, dimension, expanded=True, flat=True):
+        """Return the values along the requested dimension.
+
+        Args:
+            dimension: The dimension to return values for
+            expanded (bool, optional): Whether to expand values
+            flat (bool, optional): Whether to flatten array
+
+        Returns:
+            NumPy array of values along the requested dimension
+        """
+        index = self.get_dimension_index(dimension)
+        if index == 0:
+            return np.array([self.data])
+        elif index == 1:
+            return np.array([])
+        else:
+            return super(HSpan, self).dimension_values(dimension)
 
 
 class Spline(Annotation):

--- a/holoviews/element/comparison.py
+++ b/holoviews/element/comparison.py
@@ -134,6 +134,8 @@ class Comparison(ComparisonInterface):
         # Annotations
         cls.equality_type_funcs[VLine] =       cls.compare_vline
         cls.equality_type_funcs[HLine] =       cls.compare_hline
+        cls.equality_type_funcs[VSpan] =       cls.compare_vspan
+        cls.equality_type_funcs[HSpan] =       cls.compare_hspan
         cls.equality_type_funcs[Spline] =      cls.compare_spline
         cls.equality_type_funcs[Arrow] =       cls.compare_arrow
         cls.equality_type_funcs[Text] =        cls.compare_text
@@ -447,6 +449,14 @@ class Comparison(ComparisonInterface):
 
     @classmethod
     def compare_vline(cls, el1, el2, msg='VLine'):
+        cls.compare_annotation(el1, el2, msg=msg)
+
+    @classmethod
+    def compare_vspan(cls, el1, el2, msg='VSpan'):
+        cls.compare_annotation(el1, el2, msg=msg)
+
+    @classmethod
+    def compare_hspan(cls, el1, el2, msg='HSpan'):
         cls.compare_annotation(el1, el2, msg=msg)
 
     @classmethod

--- a/holoviews/plotting/bokeh/__init__.py
+++ b/holoviews/plotting/bokeh/__init__.py
@@ -9,7 +9,7 @@ from ...core import (Store, Overlay, NdOverlay, Layout, AdjointLayout,
 from ...element import (Curve, Points, Scatter, Image, Raster, Path,
                         RGB, Histogram, Spread, HeatMap, Contours, Bars,
                         Box, Bounds, Ellipse, Polygons, BoxWhisker, Arrow,
-                        ErrorBars, Text, HLine, VLine, Spline, Spikes,
+                        ErrorBars, Text, HLine, VLine, HSpan, VSpan, Spline, Spikes,
                         Table, ItemTable, Area, HSV, QuadMesh, VectorField,
                         Graph, Nodes, EdgePaths, Distribution, Bivariate,
                         TriMesh, Violin, Chord, Div, HexTiles, Labels, Sankey,
@@ -27,7 +27,7 @@ try:
 except:
     DFrame = None
 
-from .annotation import (TextPlot, LineAnnotationPlot, SplinePlot,
+from .annotation import (TextPlot, LineAnnotationPlot, BoxAnnotationPlot, SplinePlot,
                          ArrowPlot, DivPlot, LabelsPlot)
 from ..plot import PlotSelector
 from .callbacks import Callback # noqa (API import)
@@ -97,6 +97,8 @@ associations = {Overlay: OverlayPlot,
                 # Annotations
                 HLine: LineAnnotationPlot,
                 VLine: LineAnnotationPlot,
+                HSpan: BoxAnnotationPlot,
+                VSpan: BoxAnnotationPlot,
                 Text: TextPlot,
                 Labels: LabelsPlot,
                 Spline: SplinePlot,
@@ -199,6 +201,8 @@ options.HeatMap = Options('style', cmap='RdYlBu_r', annular_line_alpha=0,
 # Annotations
 options.HLine = Options('style', color=Cycle(), line_width=3, alpha=1)
 options.VLine = Options('style', color=Cycle(), line_width=3, alpha=1)
+options.VSpan = Options('style', color=Cycle(), alpha=0.5)
+options.HSpan = Options('style', color=Cycle(), alpha=0.5)
 options.Arrow = Options('style', arrow_size=10)
 options.Labels = Options('style', text_align='center', text_baseline='middle')
 

--- a/holoviews/plotting/bokeh/annotation.py
+++ b/holoviews/plotting/bokeh/annotation.py
@@ -18,7 +18,7 @@ except:
 from bokeh.transform import dodge
 
 from ...core.util import datetime_types, dimension_sanitizer, basestring
-from ...element import HLine, VLine, HSpan, VSpan
+from ...element import HLine, VLine, VSpan
 from ..plot import GenericElementPlot
 from .element import AnnotationPlot, ElementPlot, CompositeElementPlot, ColorbarPlot
 from .styles import text_properties, line_properties, fill_properties

--- a/holoviews/plotting/bokeh/annotation.py
+++ b/holoviews/plotting/bokeh/annotation.py
@@ -21,7 +21,7 @@ from ...core.util import datetime_types, dimension_sanitizer, basestring
 from ...element import HLine, VLine, HSpan, VSpan
 from ..plot import GenericElementPlot
 from .element import AnnotationPlot, ElementPlot, CompositeElementPlot, ColorbarPlot
-from .styles import text_properties, line_properties
+from .styles import text_properties, line_properties, fill_properties
 from .plot import BokehPlot
 from .util import date_to_integer
 
@@ -170,17 +170,17 @@ class LineAnnotationPlot(ElementPlot, AnnotationPlot):
 
 class BoxAnnotationPlot(ElementPlot, AnnotationPlot):
 
-    style_opts = line_properties + ['level', 'visible']
-
     apply_ranges = param.Boolean(default=False, doc="""
         Whether to include the annotation in axis range calculations.""")
+
+    style_opts = line_properties + fill_properties + ['level', 'visible']
 
     _plot_methods = dict(single='BoxAnnotation')
 
     def get_data(self, element, ranges, style):
         data, mapping = {}, {}
-        kwd_dim1 = 'left' if isinstance(element, HSpan) else 'bottom'
-        kwd_dim2 = 'right' if isinstance(element, HSpan) else 'top'
+        kwd_dim1 = 'left' if isinstance(element, VSpan) else 'bottom'
+        kwd_dim2 = 'right' if isinstance(element, VSpan) else 'top'
         if self.invert_axes:
             kwd_dim1 = 'bottom' if kwd_dim1 == 'left' else 'left'
             kwd_dim2 = 'top' if kwd_dim2 == 'right' else 'right'
@@ -199,17 +199,6 @@ class BoxAnnotationPlot(ElementPlot, AnnotationPlot):
         box = BoxAnnotation(level=properties.get('level', 'glyph'), **mapping)
         plot.renderers.append(box)
         return None, box
-
-    def get_extents(self, element, ranges=None, range_type='combined'):
-        locs = element.data
-        if isinstance(element, HSpan):
-            dim = 'x'
-        elif isinstance(element, VSpan):
-            dim = 'y'
-        if self.invert_axes:
-            dim = 'x' if dim == 'y' else 'x'
-        ranges[dim]['soft'] = locs
-        return super(BoxAnnotationPlot, self).get_extents(element, ranges, range_type)
 
 
 class SplinePlot(ElementPlot, AnnotationPlot):

--- a/holoviews/plotting/mpl/__init__.py
+++ b/holoviews/plotting/mpl/__init__.py
@@ -171,6 +171,8 @@ Store.register({Curve: CurvePlot,
                 # Annotation plots
                 VLine: VLinePlot,
                 HLine: HLinePlot,
+                VSpan: VSpanPlot,
+                HSpan: HSpanPlot,
                 Arrow: ArrowPlot,
                 Spline: SplinePlot,
                 Text: TextPlot,
@@ -259,6 +261,8 @@ options.GridMatrix = Options('plot', fig_size=160, shared_xaxis=True,
 # Annotations
 options.VLine = Options('style', color=Cycle())
 options.HLine = Options('style', color=Cycle())
+options.VSpan = Options('style', alpha=0.5, facecolor=Cycle())
+options.HSpan = Options('style', alpha=0.5, facecolor=Cycle())
 if config.style_17:
     options.Spline = Options('style', linewidth=2, edgecolor='r')
 else:

--- a/holoviews/plotting/mpl/annotation.py
+++ b/holoviews/plotting/mpl/annotation.py
@@ -59,7 +59,6 @@ class VLinePlot(AnnotationPlot):
             return [axis.axvline(position, **opts)]
 
 
-
 class HLinePlot(AnnotationPlot):
     "Draw a horizontal line on the axis"
 
@@ -71,6 +70,34 @@ class HLinePlot(AnnotationPlot):
             return [axis.axvline(position, **opts)]
         else:
             return [axis.axhline(position, **opts)]
+
+
+class VSpanPlot(AnnotationPlot):
+    "Draw a vertical span on the axis"
+
+    style_opts = ['alpha', 'color', 'facecolor', 'edgecolor',
+                  'linewidth', 'linestyle', 'visible']
+
+    def draw_annotation(self, axis, positions, opts):
+        "Draw a vertical span on the axis"
+        if self.invert_axes:
+            return [axis.axvspan(*positions, **opts)]
+        else:
+            return [axis.axhspan(*positions, **opts)]
+
+
+class HSpanPlot(AnnotationPlot):
+    "Draw a horizontal span on the axis"
+
+    style_opts = ['alpha', 'color', 'facecolor', 'edgecolor',
+                  'linewidth', 'linestyle', 'visible']
+
+    def draw_annotation(self, axis, positions, opts):
+        "Draw a horizontal span on the axis"
+        if self.invert_axes:
+            return [axis.axhspan(*positions, **opts)]
+        else:
+            return [axis.axvspan(*positions, **opts)]
 
 
 class TextPlot(AnnotationPlot):

--- a/holoviews/plotting/mpl/annotation.py
+++ b/holoviews/plotting/mpl/annotation.py
@@ -81,9 +81,9 @@ class VSpanPlot(AnnotationPlot):
     def draw_annotation(self, axis, positions, opts):
         "Draw a vertical span on the axis"
         if self.invert_axes:
-            return [axis.axvspan(*positions, **opts)]
-        else:
             return [axis.axhspan(*positions, **opts)]
+        else:
+            return [axis.axvspan(*positions, **opts)]
 
 
 class HSpanPlot(AnnotationPlot):
@@ -95,9 +95,9 @@ class HSpanPlot(AnnotationPlot):
     def draw_annotation(self, axis, positions, opts):
         "Draw a horizontal span on the axis"
         if self.invert_axes:
-            return [axis.axhspan(*positions, **opts)]
-        else:
             return [axis.axvspan(*positions, **opts)]
+        else:
+            return [axis.axhspan(*positions, **opts)]
 
 
 class TextPlot(AnnotationPlot):

--- a/holoviews/plotting/plotly/__init__.py
+++ b/holoviews/plotting/plotly/__init__.py
@@ -72,8 +72,10 @@ Store.register({Points: ScatterPlot,
                 Box: PathShapePlot,
                 Bounds: PathShapePlot,
                 Ellipse: PathShapePlot,
-                HLine: HLinePlot,
-                VLine: VLinePlot,
+                HLine: HVLinePlot,
+                VLine: HVLinePlot,
+                HSpan: HVSpanPlot,
+                VSpan: HVSpanPlot,
 
                 # Container Plots
                 Overlay: OverlayPlot,
@@ -111,3 +113,6 @@ options.HeatMap = Options('style', cmap='RdBu_r')
 # 3D
 options.Scatter3D = Options('style', color=Cycle(), size=6)
 
+# Annotations
+options.VSpan = Options('style', fillcolor=Cycle(), opacity=0.5)
+options.HSpan = Options('style', fillcolor=Cycle(), opacity=0.5)

--- a/holoviews/tests/plotting/bokeh/testannotationplot.py
+++ b/holoviews/tests/plotting/bokeh/testannotationplot.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from holoviews.element import HLine, VLine, Text, Labels, Arrow
+from holoviews.element import HLine, VLine, Text, Labels, Arrow, HSpan, VSpan
 
 from .testplot import TestBokehPlot, bokeh_renderer
 
@@ -8,7 +8,7 @@ from .testplot import TestBokehPlot, bokeh_renderer
 class TestHVLinePlot(TestBokehPlot):
 
     def test_hline_invert_axes(self):
-        hline = HLine(1.1).opts(plot=dict(invert_axes=True))
+        hline = HLine(1.1).opts(invert_axes=True)
         plot = bokeh_renderer.get_plot(hline)
         span = plot.handles['glyph']
         self.assertEqual(span.dimension, 'height')
@@ -22,7 +22,7 @@ class TestHVLinePlot(TestBokehPlot):
         self.assertEqual(span.location, 1.1)
 
     def test_vline_invert_axes(self):
-        vline = VLine(1.1).opts(plot=dict(invert_axes=True))
+        vline = VLine(1.1).opts(invert_axes=True)
         plot = bokeh_renderer.get_plot(vline)
         span = plot.handles['glyph']
         self.assertEqual(span.dimension, 'width')
@@ -34,6 +34,46 @@ class TestHVLinePlot(TestBokehPlot):
         span = plot.handles['glyph']
         self.assertEqual(span.dimension, 'height')
         self.assertEqual(span.location, 1.1)
+
+
+class TestHVSpanPlot(TestBokehPlot):
+    
+    def test_hspan_invert_axes(self):
+        hspan = HSpan(1.1, 1.5).opts(invert_axes=True)
+        plot = bokeh_renderer.get_plot(hspan)
+        span = plot.handles['glyph']
+
+        self.assertEqual(span.left, 1.1)
+        self.assertEqual(span.right, 1.5)
+        self.assertEqual(span.bottom, None)
+        self.assertEqual(span.top, None)
+
+    def test_hspan_plot(self):
+        hspan = HSpan(1.1, 1.5)
+        plot = bokeh_renderer.get_plot(hspan)
+        span = plot.handles['glyph']
+        self.assertEqual(span.left, None)
+        self.assertEqual(span.right, None)
+        self.assertEqual(span.bottom, 1.1)
+        self.assertEqual(span.top, 1.5)
+
+    def test_vspan_invert_axes(self):
+        vspan = VSpan(1.1, 1.5).opts(invert_axes=True)
+        plot = bokeh_renderer.get_plot(vspan)
+        span = plot.handles['glyph']
+        self.assertEqual(span.left, None)
+        self.assertEqual(span.right, None)
+        self.assertEqual(span.bottom, 1.1)
+        self.assertEqual(span.top, 1.5)
+
+    def test_vspan_plot(self):
+        vspan = VSpan(1.1, 1.5)
+        plot = bokeh_renderer.get_plot(vspan)
+        span = plot.handles['glyph']
+        self.assertEqual(span.left, 1.1)
+        self.assertEqual(span.right, 1.5)
+        self.assertEqual(span.bottom, None)
+        self.assertEqual(span.top, None)
 
 
 class TestTextPlot(TestBokehPlot):


### PR DESCRIPTION
https://github.com/pyviz/holoviews/issues/3996
Got it mostly working for bokeh, partially for matplotlib, and not touched for plotly. I need help resolving the warnings/errors.

- [x] bokeh center parameter
- [x] matplotlib datetime
- [x] plotly implementation
- [x] unit tests

Bokeh: no idea why it says I'm setting center=True; I didn't do that anywhere. I have a feeling annotation automatically passes that, but I can't find it.
![image](https://user-images.githubusercontent.com/15331990/65742016-01c60300-e0b4-11e9-9c1e-cc5e5c8fa039.png)
![image](https://user-images.githubusercontent.com/15331990/65742044-1aceb400-e0b4-11e9-8a7c-238a1f740dbb.png)

Matplotlib: datetimes don't work, I don't know why it keeps adding 1.0 to the range
![image](https://user-images.githubusercontent.com/15331990/65742067-389c1900-e0b4-11e9-98c5-f471b7de492e.png)
```
[numpy.datetime64('2017-05-01T00:00:00.000000000'), numpy.datetime64('2017-05-01T00:00:00.000000000'), 1.0]
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
~/anaconda3/lib/python3.6/site-packages/IPython/core/formatters.py in __call__(self, obj, include, exclude)
    968 
    969             if method is not None:
--> 970                 return method(include=include, exclude=exclude)
    971             return None
    972         else:

/mnt/c/Users/sephi/GOOGLE~1/Bash/holoviews/holoviews/core/dimension.py in _repr_mimebundle_(self, include, exclude)
   1290         combined and returned.
   1291         """
-> 1292         return Store.render(self)
   1293 
   1294 

/mnt/c/Users/sephi/GOOGLE~1/Bash/holoviews/holoviews/core/options.py in render(cls, obj)
   1364         data, metadata = {}, {}
   1365         for hook in hooks:
-> 1366             ret = hook(obj)
   1367             if ret is None:
   1368                 continue

/mnt/c/Users/sephi/GOOGLE~1/Bash/holoviews/holoviews/ipython/display_hooks.py in pprint_display(obj)
    279     if not ip.display_formatter.formatters['text/plain'].pprint:
    280         return None
--> 281     return display(obj, raw_output=True)
    282 
    283 

/mnt/c/Users/sephi/GOOGLE~1/Bash/holoviews/holoviews/ipython/display_hooks.py in display(obj, raw_output, **kwargs)
    249     elif isinstance(obj, (CompositeOverlay, ViewableElement)):
    250         with option_state(obj):
--> 251             output = element_display(obj)
    252     elif isinstance(obj, (Layout, NdLayout, AdjointLayout)):
    253         with option_state(obj):

/mnt/c/Users/sephi/GOOGLE~1/Bash/holoviews/holoviews/ipython/display_hooks.py in wrapped(element)
    144         try:
    145             max_frames = OutputSettings.options['max_frames']
--> 146             mimebundle = fn(element, max_frames=max_frames)
    147             if mimebundle is None:
    148                 return {}, {}

/mnt/c/Users/sephi/GOOGLE~1/Bash/holoviews/holoviews/ipython/display_hooks.py in element_display(element, max_frames)
    190         return None
    191 
--> 192     return render(element)
    193 
    194 

/mnt/c/Users/sephi/GOOGLE~1/Bash/holoviews/holoviews/ipython/display_hooks.py in render(obj, **kwargs)
     66         renderer = renderer.instance(fig='png')
     67 
---> 68     return renderer.components(obj, **kwargs)
     69 
     70 

/mnt/c/Users/sephi/GOOGLE~1/Bash/holoviews/holoviews/plotting/renderer.py in components(self, obj, fmt, comm, **kwargs)
    351             plot = obj
    352         else:
--> 353             plot, fmt = self._validate(obj, fmt)
    354 
    355         data, metadata = {}, {}

/mnt/c/Users/sephi/GOOGLE~1/Bash/holoviews/holoviews/plotting/renderer.py in _validate(self, obj, fmt, **kwargs)
    276             plot, fmt = HoloViewsPane(obj, center=True, backend=self.backend, renderer=self), fmt
    277         else:
--> 278             plot = self.get_plot(obj, renderer=self, **kwargs)
    279 
    280         all_formats = set(fig_formats + holomap_formats)

/mnt/c/Users/sephi/GOOGLE~1/Bash/holoviews/holoviews/plotting/renderer.py in get_plot(self_or_cls, obj, doc, renderer, comm, **kwargs)
    220             init_key = tuple(v if d is None else d for v, d in
    221                              zip(plot.keys[0], defaults))
--> 222             plot.update(init_key)
    223         else:
    224             plot = obj

/mnt/c/Users/sephi/GOOGLE~1/Bash/holoviews/holoviews/plotting/mpl/plot.py in update(self, key)
    247     def update(self, key):
    248         if len(self) == 1 and ((key == 0) or (key == self.keys[0])) and not self.drawn:
--> 249             return self.initialize_plot()
    250         return self.__getitem__(key)
    251 

/mnt/c/Users/sephi/GOOGLE~1/Bash/holoviews/holoviews/plotting/mpl/plot.py in wrapper(self, *args, **kwargs)
     52     def wrapper(self, *args, **kwargs):
     53         with _rc_context(self.fig_rcparams):
---> 54             return f(self, *args, **kwargs)
     55     return wrapper
     56 

/mnt/c/Users/sephi/GOOGLE~1/Bash/holoviews/holoviews/plotting/mpl/element.py in initialize_plot(self, ranges)
   1098 
   1099         return self._finalize_axis(key, element=element, ranges=ranges,
-> 1100                                    title=self._format_title(key))
   1101 
   1102 

/mnt/c/Users/sephi/GOOGLE~1/Bash/holoviews/holoviews/plotting/mpl/element.py in _finalize_axis(self, key, element, title, dimensions, ranges, xticks, yticks, zticks, xlabel, ylabel, zlabel)
    181 
    182                 # Set axes limits
--> 183                 self._set_axis_limits(axis, element, subplots, ranges)
    184 
    185             # Apply aspects

/mnt/c/Users/sephi/GOOGLE~1/Bash/holoviews/holoviews/plotting/mpl/element.py in _set_axis_limits(self, axis, view, subplots, ranges)
    319         """
    320         # Extents
--> 321         extents = self.get_extents(view, ranges)
    322         if not extents or self.overlaid:
    323             axis.autoscale_view(scalex=True, scaley=True)

/mnt/c/Users/sephi/GOOGLE~1/Bash/holoviews/holoviews/plotting/plot.py in get_extents(self, overlay, ranges, range_type)
   1538         subplot_extents = self._get_subplot_extents(overlay, ranges, range_type)
   1539         zrange = self.projection == '3d'
-> 1540         extents = {k: util.max_extents(rs, zrange) for k, rs in subplot_extents.items()}
   1541         if range_type != 'combined':
   1542             return extents[range_type]

/mnt/c/Users/sephi/GOOGLE~1/Bash/holoviews/holoviews/plotting/plot.py in <dictcomp>(.0)
   1538         subplot_extents = self._get_subplot_extents(overlay, ranges, range_type)
   1539         zrange = self.projection == '3d'
-> 1540         extents = {k: util.max_extents(rs, zrange) for k, rs in subplot_extents.items()}
   1541         if range_type != 'combined':
   1542             return extents[range_type]

/mnt/c/Users/sephi/GOOGLE~1/Bash/holoviews/holoviews/core/util.py in max_extents(extents, zrange)
   1039             if lower and isinstance(lower[0], datetime_types):
   1040                 extents[lidx] = np.min(lower)
-> 1041             elif any(isinstance(l, basestring) for l in lower):
   1042                 extents[lidx] = np.sort(lower)[0]
   1043             elif lower:

~/anaconda3/lib/python3.6/site-packages/numpy/core/fromnumeric.py in amin(a, axis, out, keepdims, initial)
   2616     """
   2617     return _wrapreduction(a, np.minimum, 'min', axis, None, out, keepdims=keepdims,
-> 2618                           initial=initial)
   2619 
   2620 

~/anaconda3/lib/python3.6/site-packages/numpy/core/fromnumeric.py in _wrapreduction(obj, ufunc, method, axis, dtype, out, **kwargs)
     84                 return reduction(axis=axis, out=out, **passkwargs)
     85 
---> 86     return ufunc.reduce(obj, axis, dtype, out, **passkwargs)
     87 
     88 

TypeError: invalid type promotion

---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-10-90bc0078bbee> in <module>()
      6 # hv.Curve([0, 1, 2, 3]) * hv.VSpan(1, 2) * hv.HSpan(1, 5)
      7 
----> 8 hv.Curve((pd.date_range('2017-05-01', '2017-05-03'), [0, 1, 2])) * hv.HSpan(*pd.date_range('2017-05-01', '2017-05-02')) * hv.VSpan(1, 2)

~/anaconda3/lib/python3.6/site-packages/IPython/core/displayhook.py in __call__(self, result)
    255             self.start_displayhook()
    256             self.write_output_prompt()
--> 257             format_dict, md_dict = self.compute_format_data(result)
    258             self.update_user_ns(result)
    259             self.fill_exec_result(result)

~/anaconda3/lib/python3.6/site-packages/IPython/core/displayhook.py in compute_format_data(self, result)
    149 
    150         """
--> 151         return self.shell.display_formatter.format(result)
    152 
    153     # This can be set to True by the write_output_prompt method in a subclass

~/anaconda3/lib/python3.6/site-packages/IPython/core/formatters.py in format(self, obj, include, exclude)
    148             return {}, {}
    149 
--> 150         format_dict, md_dict = self.mimebundle_formatter(obj, include=include, exclude=exclude)
    151 
    152         if format_dict or md_dict:

TypeError: 'NoneType' object is not iterable
```