### PR TITLE
Add support for rendering bokeh and plotly plots as gifs

### DIFF
--- a/holoviews/plotting/bokeh/renderer.py
+++ b/holoviews/plotting/bokeh/renderer.py
@@ -100,7 +100,6 @@ class BokehRenderer(Renderer):
         logger.disabled = True
 
         if fmt == 'gif':
-            from PIL import Image
             from bokeh.io.export import get_screenshot_as_png, create_webdriver
             webdriver = create_webdriver()
 
@@ -110,6 +109,7 @@ class BokehRenderer(Renderer):
                 plot.update(i)
                 img = get_screenshot_as_png(plot.state, webdriver)
                 frames.append(img)
+            webdriver.close()
 
             bio = BytesIO()
             duration = (1./self.fps)*1000


### PR DESCRIPTION
- [x] Closes https://github.com/pyviz/holoviews/issues/2956

```python
hmap = hv.HoloMap({i: hv.Curve([1, 2, i]) for i in range(10)})
hv.output(hmap, holomap='gif', fps=3, backend='matplotlib')
hv.output(hmap, holomap='gif', fps=3, backend='bokeh')
hv.output(hmap, holomap='gif', fps=3, backend='plotly')
```

![matplotlib](https://user-images.githubusercontent.com/1550771/66088309-f1fa6300-e57a-11e9-89ce-3b7ab5f15599.gif)
![bokeh](https://user-images.githubusercontent.com/1550771/66088313-f45cbd00-e57a-11e9-9e05-a8c7488b65ef.gif)
![plotly](https://user-images.githubusercontent.com/1550771/66088314-f6268080-e57a-11e9-8d9f-cf74dbd16309.gif)
