### PR TITLE
Fix issues in .apply dynamic handling

### DIFF
--- a/holoviews/core/accessors.py
+++ b/holoviews/core/accessors.py
@@ -28,6 +28,7 @@ class AccessorPipelineMeta(type):
             from ..operation.element import method as method_op, factory
             from .data import Dataset, MultiDimensionalMapping
             inst = args[0]
+
             if not hasattr(inst._obj, '_pipeline'):
                 # Wrapped object doesn't support the pipeline property
                 return __call__(*args, **kwargs)
@@ -137,6 +138,8 @@ class Apply(object):
                                  'and setting dynamic=False is only '
                                  'possible if key dimensions define '
                                  'a discrete parameter space.')
+            if not len(samples):
+                return self._obj[samples]
             return HoloMap(self._obj[samples]).apply(
                 function, streams, link_inputs, dynamic, **kwargs)
 
@@ -164,11 +167,13 @@ class Apply(object):
         )
 
         if dynamic is None:
-            dynamic = (bool(streams) or isinstance(self._obj, DynamicMap) or
-                       util.is_param_method(function, has_deps=True) or
-                       params or dependent_kws)
+            is_dynamic = (bool(streams) or isinstance(self._obj, DynamicMap) or
+                          util.is_param_method(function, has_deps=True) or
+                          params or dependent_kws)
+        else:
+            is_dynamic = dynamic
 
-        if (applies or isinstance(self._obj, HoloMap)) and dynamic:
+        if (applies or isinstance(self._obj, HoloMap)) and is_dynamic:
             return Dynamic(self._obj, operation=function, streams=streams,
                            kwargs=kwargs, link_inputs=link_inputs)
         elif applies:


### PR DESCRIPTION
Two small fixes for .apply:

1) .apply(dynamic=False) works on 0 kdim DynamicMap
2) dynamic variable is not overwritten which caused errors when using .apply on nested datastructures