### PR TITLE
support `link_selections` with Dask DataFrames

### DIFF
--- a/holoviews/tests/util/testtransform.py
+++ b/holoviews/tests/util/testtransform.py
@@ -169,8 +169,8 @@ class TestDimTransforms(ComparisonTestCase):
         self.check_apply(expr, np.sin(self.linear_floats))
 
     def test_astype_transform(self):
-        expr = dim('int').astype(str)
-        self.check_apply(expr, self.linear_ints.astype(str))
+        expr = dim('int').astype('float64')
+        self.check_apply(expr, self.linear_ints.astype('float64'))
 
     def test_cumsum_transform(self):
         expr = dim('float').cumsum()

--- a/holoviews/util/transform.py
+++ b/holoviews/util/transform.py
@@ -130,7 +130,7 @@ def categorize(values, categories, default=None):
         cats.append(cat)
     result = np.asarray(cats)
     # Convert unicode to object type like pandas does
-    if result.dtype.kind == 'U':
+    if result.dtype.kind in ['U', 'S']:
         result = result.astype('object')
     return result
 

--- a/holoviews/util/transform.py
+++ b/holoviews/util/transform.py
@@ -34,7 +34,7 @@ def norm(values, min=None, max=None):
 def lognorm(values, min=None, max=None):
     """Unity-based normalization on log scale.
        Apply the same transformation as matplotlib.colors.LogNorm
-    
+
     Args:
         values: Array of values to be normalized
         min (float, optional): Lower bound of normalization range
@@ -375,7 +375,15 @@ class dim(object):
             fn_args = [data]
             for arg in args:
                 if isinstance(arg, dim):
-                    arg = arg.apply(dataset, flat, expanded, ranges, all_values)
+                    arg = arg.apply(
+                        dataset,
+                        flat,
+                        expanded,
+                        ranges,
+                        all_values,
+                        keep_index,
+                        compute,
+                    )
                 fn_args.append(arg)
             args = tuple(fn_args[::-1] if o['reverse'] else fn_args)
             eldim = dataset.get_dimension(dimension)


### PR DESCRIPTION
Adds support for using the new `link_selections` transformation on elements backed by Dask DataFrames.

There were two problems before:
 1. The `keep_index` and `compute` args were not being passed along to subexpressions (fixed in 
c99c0cf)
 2. The `digitize` and `isin` numpy functions are not implemented as Pandas or Dask Series methods, so Dask Series were getting converted into numpy arrays.  I added custom wrappers for these functions in e38f68f.

Closes https://github.com/pyviz/holoviews/issues/4034

TODO:
 - [x] Tests: We should add tests across all dim transformations to make sure they preserve dask Series as Series when appropriate.