### PR TITLE
Make it possible to apply linked_selection to most DynamicMaps

### DIFF
--- a/holoviews/core/data/__init__.py
+++ b/holoviews/core/data/__init__.py
@@ -279,6 +279,7 @@ class Dataset(Element):
             chain as chain_op, factory
         )
         self._in_method = False
+        input_data = data
         input_dataset = kwargs.pop('dataset', None)
         input_pipeline = kwargs.pop(
             'pipeline', None
@@ -318,7 +319,8 @@ class Dataset(Element):
         self._dataset = None
         if input_dataset is not None:
             self._dataset = input_dataset.clone(dataset=None, pipeline=None)
-
+        elif isinstance(input_data, Dataset):
+            self._dataset = input_data._dataset
         elif type(self) is Dataset:
             self._dataset = self
 

--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -640,6 +640,11 @@ class Callable(param.Parameterized):
          based on the call arguments and any streams attached to the
          inputs.""")
 
+    operation = param.Callable(default=None, doc="""
+         The function being applied by the Callable. May be used
+         to record the transform(s) being applied inside the
+         callback function.""")
+
     stream_mapping = param.Dict(default={}, constant=True, doc="""
          Defines how streams should be mapped to objects returned by
          the Callable, e.g. when it returns a Layout.""")

--- a/holoviews/operation/element.py
+++ b/holoviews/operation/element.py
@@ -102,7 +102,7 @@ class function(Operation):
     input_type = param.ClassSelector(class_=type, doc="""
         The object type the method is defined on""")
 
-    fn = param.Callable(default=lambda el, *args, **kwargs: x, doc="""
+    fn = param.Callable(default=lambda el, *args, **kwargs: el, doc="""
         The function to apply.""")
 
     args = param.List(default=[], doc="""

--- a/holoviews/operation/element.py
+++ b/holoviews/operation/element.py
@@ -85,33 +85,55 @@ class factory(Operation):
         the corresponding RGB element will be returned. """)
 
     args = param.List(default=[], doc="""
-            The list of positional argument to pass to the factory""")
+        The list of positional argument to pass to the factory""")
 
     kwargs = param.Dict(default={}, doc="""
-            The dict of keyword arguments to pass to the factory""")
+        The dict of keyword arguments to pass to the factory""")
 
     def _process(self, view, key=None):
         return self.p.output_type(view, *self.p.args, **self.p.kwargs)
+
+
+class function(Operation):
+
+    output_type = param.ClassSelector(class_=type, doc="""
+        The output type of the method operation""")
+
+    input_type = param.ClassSelector(class_=type, doc="""
+        The object type the method is defined on""")
+
+    fn = param.Callable(default=lambda el, *args, **kwargs: x, doc="""
+        The function to apply.""")
+
+    args = param.List(default=[], doc="""
+        The list of positional argument to pass to the method""")
+
+    kwargs = param.Dict(default={}, doc="""
+        The dict of keyword arguments to pass to the method""")
+
+    def _process(self, element, key=None):
+        return self.p.fn(element, *self.p.args, **self.p.kwargs)
 
 
 class method(Operation):
     """
     Operation that wraps a method call
     """
+
     output_type = param.ClassSelector(class_=type, doc="""
-            The output type of the method operation""")
+        The output type of the method operation""")
 
     input_type = param.ClassSelector(class_=type, doc="""
-            The object type the method is defined on""")
+        The object type the method is defined on""")
 
     method_name = param.String(default='__call__', doc="""
-            The method name""")
+        The method name""")
 
     args = param.List(default=[], doc="""
-            The list of positional argument to pass to the method""")
+        The list of positional argument to pass to the method""")
 
     kwargs = param.Dict(default={}, doc="""
-            The dict of keyword arguments to pass to the method""")
+        The dict of keyword arguments to pass to the method""")
 
     def _process(self, element, key=None):
         fn = getattr(self.p.input_type, self.p.method_name)

--- a/holoviews/selection.py
+++ b/holoviews/selection.py
@@ -5,12 +5,12 @@ import param
 
 from param.parameterized import bothmethod
 
-from . import Overlay
-from .core import OperationCallable
-from .streams import SelectionExpr, Stream
+from .core import OperationCallable, Overlay
 from .core.element import Element, Layout
-from .util import Dynamic, DynamicMap
 from .core.options import Store
+from .streams import SelectionExpr, Stream
+from .operation.element import function
+from .util import Dynamic, DynamicMap
 from .plotting.util import initialize_dynamic, linear_gradient
 
 _Cmap = Stream.define('Cmap', cmap=[])
@@ -79,11 +79,13 @@ class _base_link_selections(param.ParameterizedFunction):
         if isinstance(hvobj, DynamicMap):
             initialize_dynamic(hvobj)
 
-            if (isinstance(hvobj.callback, OperationCallable) and
-                    len(hvobj.callback.inputs) == 1):
-
+            if len(hvobj.callback.inputs) == 1 and hvobj.callback.operation:
                 child_hvobj = hvobj.callback.inputs[0]
-                next_op = hvobj.callback.operation
+                if isinstance(hvobj.callback, OperationCallable):
+                    next_op = hvobj.callback.operation
+                else:
+                    fn = hvobj.callback.operation
+                    next_op = function.instance(fn=fn)
                 new_operations = (next_op,) + operations
 
                 # Recurse on child with added operation

--- a/holoviews/util/__init__.py
+++ b/holoviews/util/__init__.py
@@ -933,19 +933,19 @@ class Dynamic(param.ParameterizedFunction):
         Generate function to dynamically apply the operation.
         Wraps an existing HoloMap or DynamicMap.
         """
-        def resolve(key):
+        def resolve(key, kwargs):
             if not isinstance(map_obj, HoloMap):
-                return map_obj
+                return key, map_obj
             elif isinstance(map_obj, DynamicMap) and map_obj._posarg_keys and not key:
                 key = tuple(kwargs[k] for k in map_obj._posarg_keys)
-            return map_obj[key]
+            return key, map_obj[key]
 
         def apply(element, *key, **kwargs):
             kwargs = dict(util.resolve_dependent_kwargs(self.p.kwargs), **kwargs)
             return self._process(element, key, kwargs)
 
         def dynamic_operation(*key, **kwargs):
-            obj = resolve(key)
+            key, obj = resolve(key, kwargs)
             return apply(obj, *key, **kwargs)
 
         if isinstance(self.p.operation, Operation):


### PR DESCRIPTION
When using ``linked_selection`` with various DynamicMaps I'd very frequently encounter situations where it could not recurse into the DynamicMap because it could not reconstruct the operations being applied. This PR ensures that all ``Dynamic`` operations record the transform they are applying making it possible to use linked_selections on almost all DynamicMaps.