### PR TITLE
Fixed title formatter in GenericElementPlot

### DIFF
--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -488,7 +488,7 @@ class DimensionedPlot(Plot):
 
     def _format_title(self, key, dimensions=True, separator='\n'):
         if self.title_format and util.config.future_deprecations:
-            self.param.warning('title_format is deprecated. Use title')
+            self.param.warning('title_format is deprecated. Please use title instead')
 
         label, group, type_name, dim_title = self._format_title_components(
             key, dimensions=True, separator='\n'

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -486,6 +486,39 @@ class DimensionedPlot(Plot):
         return util.bytes_to_unicode(separator.join(g for g in groups if g))
 
 
+    def _format_title(self, key, dimensions=True, separator='\n'):
+        label, group, type_name, dim_title = self._format_title_components(
+            key, dimensions=True, separator='\n'
+        )
+
+        custom_title = (self.title != self.param.params('title').default)
+        if custom_title and self.title_format:
+            self.warning('Both title and title_format set. Using title parameter')
+        title_str = (
+            self.title if custom_title or self.title_format is None
+            else self.title_format
+        )
+
+        title = util.bytes_to_unicode(title_str).format(
+            label=util.bytes_to_unicode(label),
+            group=util.bytes_to_unicode(group),
+            type=type_name,
+            dimensions=dim_title
+        )
+        return title.strip(' \n')
+
+
+    def _format_title_components(self, key, dimensions=True, separator='\n'):
+        """
+        Determine components of title as used by _format_title method.
+
+        To be overridden in child classes.
+
+        Return signature: (label, group, type_name, dim_title)
+        """
+        return (self.label, self.group, type(self).__name__, '')
+
+
     def _fontsize(self, key, label='fontsize', common=True):
         if not self.fontsize: return {}
 
@@ -1242,33 +1275,19 @@ class GenericElementPlot(DimensionedPlot):
         return xlabel, ylabel, zlabel
 
 
-    def _format_title(self, key, dimensions=True, separator='\n'):
+    def _format_title_components(self, key, dimensions=True, separator='\n'):
         frame = self._get_frame(key)
         if frame is None: return None
         type_name = type(frame).__name__
         group = frame.group if frame.group != type_name else ''
         label = frame.label
 
-        if self.layout_dimensions:
+        if self.layout_dimensions or dimensions:
             dim_title = self._frame_title(key, separator=separator)
-            title = dim_title
         else:
-            if dimensions:
-                dim_title = self._frame_title(key, separator=separator)
-            else:
-                dim_title = ''
+            dim_title = ''
 
-        custom_title = (self.title != self.param.params('title').default)
-        if custom_title and self.title_format:
-            self.warning('Both title and title_format set. Using title_format parameter')
-
-        title = self.title if custom_title or self.title_format is None else self.title_format
-        title_format = util.bytes_to_unicode(title)
-        title = title_format.format(label=util.bytes_to_unicode(label),
-                                    group=util.bytes_to_unicode(group),
-                                    type=type_name,
-                                    dimensions=dim_title)
-        return title.strip(' \n')
+        return (label, group, type_name, dim_title)
 
 
     def update_frame(self, key, ranges=None):
@@ -1655,24 +1674,13 @@ class GenericCompositePlot(DimensionedPlot):
         return layout_frame
 
 
-    def _format_title(self, key, dimensions=True, separator='\n'):
+    def _format_title_components(self, key, dimensions=True, separator='\n'):
         dim_title = self._frame_title(key, 3, separator) if dimensions else ''
         layout = self.layout
         type_name = type(self.layout).__name__
         group = util.bytes_to_unicode(layout.group if layout.group != type_name else '')
         label = util.bytes_to_unicode(layout.label)
-
-
-        custom_title = (self.title != self.param.params('title').default)
-        if custom_title and self.title_format:
-            self.warning('Both title and title_format set. Using title parameter')
-        title_str = self.title if custom_title or self.title_format is None else self.title_format
-
-        title = util.bytes_to_unicode(title_str).format(label=label,
-                                                        group=group,
-                                                        type=type_name,
-                                                        dimensions=dim_title)
-        return title.strip(' \n')
+        return (label, group, type_name, dim_title)
 
 
 class GenericLayoutPlot(GenericCompositePlot):

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -487,13 +487,16 @@ class DimensionedPlot(Plot):
 
 
     def _format_title(self, key, dimensions=True, separator='\n'):
+        if self.title_format and util.config.future_deprecations:
+            self.param.warning('title_format is deprecated. Use title')
+
         label, group, type_name, dim_title = self._format_title_components(
             key, dimensions=True, separator='\n'
         )
 
         custom_title = (self.title != self.param.params('title').default)
         if custom_title and self.title_format:
-            self.warning('Both title and title_format set. Using title parameter')
+            self.warning('Both title and title_format set. Using title')
         title_str = (
             self.title if custom_title or self.title_format is None
             else self.title_format

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -1258,16 +1258,16 @@ class GenericElementPlot(DimensionedPlot):
             else:
                 dim_title = ''
 
-            custom_title = (self.title != self.param.params('title').default)
-            if custom_title and self.title_format:
-                self.warning('Both title and title_format set. Using title_format parameter')
+        custom_title = (self.title != self.param.params('title').default)
+        if custom_title and self.title_format:
+            self.warning('Both title and title_format set. Using title_format parameter')
 
-            title = self.title if custom_title or self.title_format is None else self.title_format
-            title_format = util.bytes_to_unicode(title)
-            title = title_format.format(label=util.bytes_to_unicode(label),
-                                        group=util.bytes_to_unicode(group),
-                                        type=type_name,
-                                        dimensions=dim_title)
+        title = self.title if custom_title or self.title_format is None else self.title_format
+        title_format = util.bytes_to_unicode(title)
+        title = title_format.format(label=util.bytes_to_unicode(label),
+                                    group=util.bytes_to_unicode(group),
+                                    type=type_name,
+                                    dimensions=dim_title)
         return title.strip(' \n')
 
 

--- a/holoviews/tests/plotting/bokeh/testelementplot.py
+++ b/holoviews/tests/plotting/bokeh/testelementplot.py
@@ -8,6 +8,7 @@ from holoviews.core import Dimension, DynamicMap, NdOverlay, HoloMap
 from holoviews.element import Curve, Image, Scatter, Labels
 from holoviews.streams import Stream, PointDraw
 from holoviews.plotting.util import process_cmap
+from holoviews.util import render
 
 from .testplot import TestBokehPlot, bokeh_renderer
 from ...utils import LoggingComparisonTestCase
@@ -100,6 +101,17 @@ class TestElementPlot(LoggingComparisonTestCase, TestBokehPlot):
         self.assertEqual(yaxis.minor_tick_line_color, None)
         self.assertEqual(yaxis.major_tick_line_color, None)
         self.assertTrue(yaxis in plot.state.right)
+
+    def test_element_title_format(self):
+        title_str = ('Label: {label}, group: {group}, '
+                     'dims: {dimensions}, type: {type}')
+        e = Scatter(
+            [],
+            label='the_label',
+            group='the_group',
+        ).opts(title=title_str)
+        title = 'Label: the_label, group: the_group, dims: , type: Scatter'
+        self.assertEqual(render(e).title.text, title)
 
     def test_element_xformatter_string(self):
         curve = Curve(range(10)).options(xformatter='%d')

--- a/holoviews/tests/plotting/bokeh/testlayoutplot.py
+++ b/holoviews/tests/plotting/bokeh/testlayoutplot.py
@@ -1,15 +1,18 @@
+import re
+
 import numpy as np
 
 from holoviews.core import (HoloMap, GridSpace, Layout, Empty, Dataset,
-                            NdOverlay, DynamicMap, Dimension)
-from holoviews.element import Curve, Image, Points, Histogram
+                            NdOverlay, NdLayout, DynamicMap, Dimension)
+from holoviews.element import Curve, Image, Points, Histogram, Scatter
 from holoviews.streams import Stream
+from holoviews.util import render, opts
 
 from .testplot import TestBokehPlot, bokeh_renderer
 
 try:
     from bokeh.layouts import Column, Row
-    from bokeh.models import Div, ToolbarBox, GlyphRenderer, Tabs, Panel, Spacer, GridBox
+    from bokeh.models import Div, ToolbarBox, GlyphRenderer, Tabs, Panel, Spacer, GridBox, Title
     from bokeh.plotting import Figure
 except:
     pass
@@ -39,6 +42,39 @@ class TestLayoutPlot(TestBokehPlot):
         text = ('<span style="color:black;font-family:Arial;font-style:bold;'
                 'font-weight:bold;font-size:12pt">Default: 0</span>')
         self.assertEqual(title.text, text)
+
+    def test_layout_title_format(self):
+        title_str = ('Label: {label}, group: {group}, '
+                     'dims: {dimensions}, type: {type}')
+        layout = NdLayout(
+            {'Element 1': Scatter(
+                [],
+                label='ONE',
+                group='first',
+            ), 'Element 2': Scatter(
+                [],
+                label='TWO',
+                group='second',
+            )},
+            kdims='MYDIM',
+            label='the_label',
+            group='the_group',
+        ).opts(opts.NdLayout(title=title_str), opts.Scatter(title=title_str))
+        # Title of NdLayout
+        title = bokeh_renderer.get_plot(layout).handles['title']
+        self.assertIsInstance(title, Div)
+        text = 'Label: the_label, group: the_group, dims: , type: NdLayout'
+        self.assertEqual(re.split('>|</', title.text)[1], text)
+        # Titles of subplots
+        plot = render(layout)
+        titles = {
+            title.text for title in list(plot.select({'type': Title}))
+        }
+        titles_correct = {
+            'Label: ONE, group: first, dims: MYDIM: Element 1, type: Scatter',
+            'Label: TWO, group: second, dims: MYDIM: Element 2, type: Scatter',
+        }
+        self.assertEqual(titles_correct, titles)
 
     def test_layout_title_fontsize(self):
         hmap1 = HoloMap({a: Image(np.random.rand(10,10)) for a in range(3)})


### PR DESCRIPTION
Before: 
![Screen Shot 2019-10-16 at 2 38 29 PM](https://user-images.githubusercontent.com/38992106/66948623-0c284c80-f023-11e9-8258-2d6de6a97f2d.png)

After:
![Screen Shot 2019-10-16 at 2 46 15 PM](https://user-images.githubusercontent.com/38992106/66949004-bdc77d80-f023-11e9-9e33-763df21e83fb.png)

 This said, I would also like to point out that the `_format_title` methods of `GenericElementPlot` and `GenericCompositePlot` look pretty similar, and both classes directly derive from `DimensionedPlot`, yet when both `title` and `title_format` are set, one falls back to `title`, the other one to `title_format`. I don't know if there was a special reason why the two classes have separate implementations but I think the code could potentially be clearer.


```
from holoviews import opts
import holoviews as hv
hv.extension('bokeh')
# hv.extension('matplotlib')

l = hv.NdLayout({'FOO': hv.Scatter([], group='ONE'), 'BAR': hv.Scatter([], label='TWO')}, kdims='MYDIM').opts(
    opts.Scatter(title_format='this {label} is {group} my {dimensions} formatter')
)
l
```